### PR TITLE
Allow luminance map to be reused

### DIFF
--- a/lib/Potrace.js
+++ b/lib/Potrace.js
@@ -1,176 +1,103 @@
-/* 
+'use strict';
+
+
+var Jimp = require('jimp');
+var Bitmap = require('./types/Bitmap');
+var Curve = require('./types/Curve');
+var Point = require('./types/Point');
+var Path = require('./types/Path');
+var Quad = require('./types/Quad');
+var Sum = require('./types/Sum');
+var Opti = require('./types/Opti');
+
+var utils = require('./utils');
+
+/*
  * A javascript port of Potrace (http://potrace.sourceforge.net).
  * Converted for use outside of the browser, such as NodeJS.
- * 
+ *
  * Licensed under the GPL
- * 
+ *
  * Usage
  *   loadImage(file) : load image from File API or URL
  *     input color/grayscale image is simply converted to binary image. no pre-
  *     process is performed.
- * 
+ *
  *   setParameter({para1: value, ...}) : set parameters
  *     parameters:
  *        turnpolicy ("black" / "white" / "left" / "right" / "minority" / "majority")
- *          how to resolve ambiguities in path decomposition. (default: "minority")       
+ *          how to resolve ambiguities in path decomposition. (default: "minority")
  *        turdsize
  *          suppress speckles of up to this size (default: 2)
  *        optcurve (true / false)
  *          turn on/off curve optimization (default: true)
  *        alphamax
  *          corner threshold parameter (default: 1)
- *        opttolerance 
+ *        opttolerance
  *          curve optimization tolerance (default: 0.2)
  *        blacklevel (0-255)
  *          below this value of brightness a pixel is considered black (default: 128)
- *       
+ *
  *   process(callback) : wait for the image be loaded, then run potrace algorithm,
  *                       then call callback function.
- * 
+ *
  *   getSVG(size, opt_type) : return a string of generated SVG image.
  *                                    result_image_size = original_image_size * size
  *                                    optional parameter opt_type can be "curve"
  */
+function Potrace2 () {
+	this._bitmap = null;
+	this._pathlist = [];
 
-var Jimp = require('jimp');
+	this._imageLoading = false;
+	this._imageLoaded = false;
+	this._processed = false;
 
-var Potrace = (function() {
+	this._params = {
+		turnpolicy: "minority",
+		turdsize: 2,
+		optcurve: true,
+		alphamax: 1,
+		opttolerance: 0.2,
+		blacklevel: 128
+	}
+}
 
-  function Point(x, y) {
-    this.x = x;
-    this.y = y;
-  }
-  
-  Point.prototype.copy = function(){
-    return new Point(this.x, this.y);
-  };
+Potrace2.prototype = {
+  _bmToPathlist: function() {
+    var self = this,
+        bitmap = this._bitmap.copy(),
+        currentPoint = new Point(0, 0),
+        path;
 
-  function Bitmap(w, h) {
-    this.w = w;
-    this.h = h;
-    this.size = w * h;
-    this.arraybuffer = new ArrayBuffer(this.size);
-    this.data = new Int8Array(this.arraybuffer);
-  }
-
-  Bitmap.prototype.at = function (x, y) {
-    return (x >= 0 && x < this.w && y >=0 && y < this.h) && 
-        this.data[this.w * y + x] === 1;
-  };
-
-  Bitmap.prototype.index = function(i) {
-    var point = new Point();
-    point.y = Math.floor(i / this.w);
-    point.x = i - point.y * this.w;
-    return point;
-  };
-
-  Bitmap.prototype.flip = function(x, y) {
-    if (this.at(x, y)) {
-      this.data[this.w * y + x] = 0;
-    } else {
-      this.data[this.w * y + x] = 1;
-    }
-  };
-    
-  Bitmap.prototype.copy = function() {
-    var bm = new Bitmap(this.w, this.h), i;
-    for (i = 0; i < this.size; i++) {
-      bm.data[i] = this.data[i];
-    }
-    return bm;
-  };
-
-  function Path() {
-    this.area = 0;
-    this.len = 0;
-    this.curve = {};
-    this.pt = [];
-    this.minX = 100000;
-    this.minY = 100000;
-    this.maxX= -1;
-    this.maxY = -1;
-  }
-
-  function Curve(n) {
-    this.n = n;
-    this.tag = new Array(n);
-    this.c = new Array(n * 3);
-    this.alphaCurve = 0;
-    this.vertex = new Array(n);
-    this.alpha = new Array(n);
-    this.alpha0 = new Array(n);
-    this.beta = new Array(n);
-  }
-
-  var jimpImg,
-      bm = null,
-      pathlist = [],
-      callback,
-      info = {
-        isReady: false,
-        turnpolicy: "minority", 
-        turdsize: 2,
-        optcurve: true,
-        alphamax: 1,
-        opttolerance: 0.2,
-        blacklevel: 128
-      };
-
-  function loadImage(target, cb) {
-    if (info.isReady) {
-      clear();
-    }
-    Jimp.read(target, function(err, img){
-      if (err) return cb(err);
-      jimpImg = img;
-
-      // create B&W bitmap
-      bm = new Bitmap(img.bitmap.width, img.bitmap.height);
-      var imgdataobj = img.bitmap.data, color;
-      img.scan(0, 0, img.bitmap.width, img.bitmap.height, function (x, y, idx) {
-        color = 0.2126 * imgdataobj[idx] + 0.7153 * imgdataobj[idx + 1] +
-          0.0721 * imgdataobj[idx + 2];
-        bm.data[idx/4] = (color < info.blacklevel ? 1 : 0);
-      });
-      info.isReady = true;
-      cb(null);
-    });
-  }
-  
-  function setParameter(obj) {
-   var key;
-   for (key in obj) {
-     if (obj.hasOwnProperty(key)) {
-       info[key] = obj[key];
-     }
-    }
-  }
-  
-  function bmToPathlist() {
-  
-    var bm1 = bm.copy(),
-      currentPoint = new Point(0, 0),
-      path;
-    
+	  /**
+     * finds next black pixel of the image
+     *
+     * @param point
+     * @returns {boolean|*}
+     */
     function findNext(point) {
-      var i = bm1.w * point.y + point.x;
-      while (i < bm1.size && bm1.data[i] !== 1) {
+      var i = bitmap.w * point.y + point.x;
+
+      while (i < bitmap.size && bitmap.data[i] !== 1) {
         i++;
       }
-      return i < bm1.size && bm1.index(i);
+
+      return i < bitmap.size && bitmap.index(i);
     }
-    
+
     function majority(x, y) {
       var i, a, ct;
+
       for (i = 2; i < 5; i++) {
         ct = 0;
         for (a = -i + 1; a <= i - 1; a++) {
-          ct += bm1.at(x + a, y + i - 1) ? 1 : -1;
-          ct += bm1.at(x + i - 1, y + a - 1) ? 1 : -1;
-          ct += bm1.at(x + a - 1, y - i) ? 1 : -1;
-          ct += bm1.at(x - i, y + a) ? 1 : -1;
+          ct += bitmap.at(x + a, y + i - 1) ? 1 : -1;
+          ct += bitmap.at(x + i - 1, y + a - 1) ? 1 : -1;
+          ct += bitmap.at(x + a - 1, y - i) ? 1 : -1;
+          ct += bitmap.at(x - i, y + a) ? 1 : -1;
         }
+
         if (ct > 0) {
           return 1;
         } else if (ct < 0) {
@@ -179,14 +106,17 @@ var Potrace = (function() {
       }
       return 0;
     }
-    
+
     function findPath(point) {
       var path = new Path(),
-        x = point.x, y = point.y,
-        dirx = 0, diry = 1, tmp;
-      
-      path.sign = bm.at(point.x, point.y) ? "+" : "-";
-      
+          x = point.x,
+          y = point.y,
+          dirx = 0,
+          diry = 1,
+          tmp;
+
+      path.sign = bitmap.at(point.x, point.y) ? "+" : "-";
+
       while (1) {
         path.pt.push(new Point(x, y));
         if (x > path.maxX)
@@ -198,23 +128,23 @@ var Potrace = (function() {
         if (y < path.minY)
           path.minY = y;
         path.len++;
-        
+
         x += dirx;
         y += diry;
         path.area -= x * diry;
-        
+
         if (x === point.x && y === point.y)
           break;
-        
-        var l = bm1.at(x + (dirx + diry - 1 ) / 2, y + (diry - dirx - 1) / 2);
-        var r = bm1.at(x + (dirx - diry - 1) / 2, y + (diry + dirx - 1) / 2);
-        
+
+        var l = bitmap.at(x + (dirx + diry - 1 ) / 2, y + (diry - dirx - 1) / 2);
+        var r = bitmap.at(x + (dirx - diry - 1) / 2, y + (diry + dirx - 1) / 2);
+
         if (r && !l) {
-          if (info.turnpolicy === "right" ||
-          (info.turnpolicy === "black" && path.sign === '+') ||
-          (info.turnpolicy === "white" && path.sign === '-') ||
-          (info.turnpolicy === "majority" && majority(x, y)) ||
-          (info.turnpolicy === "minority" && !majority(x, y))) {
+          if (self._params.turnpolicy === "right" ||
+            (self._params.turnpolicy === "black" && path.sign === '+') ||
+            (self._params.turnpolicy === "white" && path.sign === '-') ||
+            (self._params.turnpolicy === "majority" && majority(x, y)) ||
+            (self._params.turnpolicy === "minority" && !majority(x, y))) {
             tmp = dirx;
             dirx = -diry;
             diry = tmp;
@@ -235,211 +165,45 @@ var Potrace = (function() {
       }
       return path;
     }
-    
+
     function xorPath(path){
       var y1 = path.pt[0].y,
         len = path.len,
         x, y, maxX, minY, i, j;
+
       for (i = 1; i < len; i++) {
         x = path.pt[i].x;
         y = path.pt[i].y;
-        
+
         if (y !== y1) {
           minY = y1 < y ? y1 : y;
           maxX = path.maxX;
           for (j = x; j < maxX; j++) {
-            bm1.flip(j, minY);
+            bitmap.flip(j, minY);
           }
           y1 = y;
         }
       }
-      
     }
-    
+
     while (currentPoint = findNext(currentPoint)) {
-
       path = findPath(currentPoint);
-      
       xorPath(path);
-      
-      if (path.area > info.turdsize) {
-        pathlist.push(path);
-      }
-    }
-    
-  }
-  
 
-  function processPath() {
-  
-    function Quad() {
-      this.data = [0,0,0,0,0,0,0,0,0];
+      if (path.area > self._params.turdsize) {
+        this._pathlist.push(path);
+      }
     }
+  },
 
-    Quad.prototype.at = function(x, y) {
-      return this.data[x * 3 + y];
-    };
-    
-    function Sum(x, y, xy, x2, y2) {
-      this.x = x;
-      this.y = y;
-      this.xy = xy;
-      this.x2 = x2;
-      this.y2 = y2;
-    }
-    
-    function mod(a, n) {
-        return a >= n ? a % n : a>=0 ? a : n-1-(-1-a) % n;
-    }
-  
-    function xprod(p1, p2) {
-      return p1.x * p2.y - p1.y * p2.x;
-    }
-    
-    function cyclic(a, b, c) {
-      if (a <= c) {
-        return (a <= b && b < c);
-      } else {
-        return (a <= b || b < c);
-      }
-    }
-      
-    function sign(i) {
-      return i > 0 ? 1 : i < 0 ? -1 : 0;
-    }
-    
-    function quadform(Q, w) {
-      var v = new Array(3), i, j, sum;
-    
-      v[0] = w.x;
-      v[1] = w.y;
-      v[2] = 1;
-      sum = 0.0;
-    
-      for (i=0; i<3; i++) {
-        for (j=0; j<3; j++) {
-          sum += v[i] * Q.at(i, j) * v[j];
-        }
-      }
-      return sum;
-    }
-  
-    function interval(lambda, a, b) {
-      var res = new Point();
-    
-      res.x = a.x + lambda * (b.x - a.x);
-      res.y = a.y + lambda * (b.y - a.y);
-      return res;
-    }
-    
-    function dorth_infty(p0, p2) {
-      var r = new Point();
-      
-      r.y = sign(p2.x - p0.x);
-      r.x = -sign(p2.y - p0.y);
-    
-      return r;
-    }
-    
-    function ddenom(p0, p2) {
-      var r = dorth_infty(p0, p2);
-    
-      return r.y * (p2.x - p0.x) - r.x * (p2.y - p0.y);
-    }
-    
-    function dpara(p0, p1, p2) {
-      var x1, y1, x2, y2;
-    
-      x1 = p1.x - p0.x;
-      y1 = p1.y - p0.y;
-      x2 = p2.x - p0.x;
-      y2 = p2.y - p0.y;
-    
-      return x1 * y2 - x2 * y1;
-    }
-    
-    function cprod(p0, p1, p2, p3) {
-      var x1, y1, x2, y2;
-    
-      x1 = p1.x - p0.x;
-      y1 = p1.y - p0.y;
-      x2 = p3.x - p2.x;
-      y2 = p3.y - p2.y;
-    
-      return x1 * y2 - x2 * y1;
-    }
-      
-    function iprod(p0, p1, p2) {
-      var x1, y1, x2, y2;
-    
-      x1 = p1.x - p0.x;
-      y1 = p1.y - p0.y;
-      x2 = p2.x - p0.x;
-      y2 = p2.y - p0.y;
-    
-      return x1*x2 + y1*y2;
-    }
-      
-    function iprod1(p0, p1, p2, p3) {
-      var x1, y1, x2, y2;
-    
-      x1 = p1.x - p0.x;
-      y1 = p1.y - p0.y;
-      x2 = p3.x - p2.x;
-      y2 = p3.y - p2.y;
-    
-      return x1 * x2 + y1 * y2;
-    }
-    
-    function ddist(p, q) {
-      return Math.sqrt((p.x - q.x) * (p.x - q.x) + (p.y - q.y) * (p.y - q.y));
-    }
-    
-    function bezier(t, p0, p1, p2, p3) {
-      var s = 1 - t, res = new Point();
-    
-      res.x = s*s*s*p0.x + 3*(s*s*t)*p1.x + 3*(t*t*s)*p2.x + t*t*t*p3.x;
-      res.y = s*s*s*p0.y + 3*(s*s*t)*p1.y + 3*(t*t*s)*p2.y + t*t*t*p3.y;
-    
-      return res;
-    }
-  
-    function tangent(p0, p1, p2, p3, q0, q1) {
-      var A, B, C, a, b, c, d, s, r1, r2;
-    
-      A = cprod(p0, p1, q0, q1);
-      B = cprod(p1, p2, q0, q1);
-      C = cprod(p2, p3, q0, q1);
-    
-      a = A - 2 * B + C;
-      b = -2 * A + 2 * B;
-      c = A;
-      
-      d = b * b - 4 * a * c;
-    
-      if (a===0 || d<0) {
-        return -1.0;
-      }
-    
-      s = Math.sqrt(d);
-    
-      r1 = (-b + s) / (2 * a);
-      r2 = (-b - s) / (2 * a);
-    
-      if (r1 >= 0 && r1 <= 1) {
-        return r1;
-      } else if (r2 >= 0 && r2 <= 1) {
-        return r2;
-      } else {
-        return -1.0;
-      }
-    }
-    
+  _processPath: function() {
+    var self = this;
+
     function calcSums(path) {
       var i, x, y;
       path.x0 = path.pt[0].x;
       path.y0 = path.pt[0].y;
-      
+
       path.sums = [];
       var s = path.sums;
       s.push(new Sum(0, 0, 0, 0, 0));
@@ -450,21 +214,24 @@ var Potrace = (function() {
             s[i].x2 + x * x, s[i].y2 + y * y));
       }
     }
-   
+
     function calcLon(path) {
-      
-      var n = path.len, pt = path.pt, dir,
-        pivk = new Array(n),
-        nc = new Array(n),
-        ct = new Array(4);
+
+      var n = path.len,
+          pt = path.pt,
+          dir,
+          pivk = new Array(n),
+          nc = new Array(n),
+          ct = new Array(4);
+
       path.lon = new Array(n);
-      
+
       var constraint = [new Point(), new Point()],
           cur = new Point(),
           off = new Point(),
           dk = new Point(),
           foundk;
-      
+
       var i, j, k1, a, b, c, d, k = 0;
       for(i = n - 1; i >= 0; i--){
         if (pt[i].x != pt[k].x && pt[i].y != pt[k].y) {
@@ -472,101 +239,103 @@ var Potrace = (function() {
         }
         nc[i] = k;
       }
-      
+
       for (i = n - 1; i >= 0; i--) {
         ct[0] = ct[1] = ct[2] = ct[3] = 0;
-        dir = (3 + 3 * (pt[mod(i + 1, n)].x - pt[i].x) + 
-            (pt[mod(i + 1, n)].y - pt[i].y)) / 2;
+        dir = (3 + 3 * (pt[utils.mod(i + 1, n)].x - pt[i].x) +
+            (pt[utils.mod(i + 1, n)].y - pt[i].y)) / 2;
         ct[dir]++;
-        
+
         constraint[0].x = 0;
         constraint[0].y = 0;
         constraint[1].x = 0;
         constraint[1].y = 0;
-        
+
         k = nc[i];
         k1 = i;
         while (1) {
           foundk = 0;
-          dir =  (3 + 3 * sign(pt[k].x - pt[k1].x) + 
-              sign(pt[k].y - pt[k1].y)) / 2;
+          dir =  (3 + 3 * utils.sign(pt[k].x - pt[k1].x) +
+              utils.sign(pt[k].y - pt[k1].y)) / 2;
           ct[dir]++;
-          
+
           if (ct[0] && ct[1] && ct[2] && ct[3]) {
             pivk[i] = k1;
             foundk = 1;
             break;
           }
-          
+
           cur.x = pt[k].x - pt[i].x;
           cur.y = pt[k].y - pt[i].y;
-          
-          if (xprod(constraint[0], cur) < 0 || xprod(constraint[1], cur) > 0) {
+
+          if (utils.xprod(constraint[0], cur) < 0 || utils.xprod(constraint[1], cur) > 0) {
             break;
           }
-              
+
           if (Math.abs(cur.x) <= 1 && Math.abs(cur.y) <= 1) {
-          
+
           } else {
             off.x = cur.x + ((cur.y >= 0 && (cur.y > 0 || cur.x < 0)) ? 1 : -1);
             off.y = cur.y + ((cur.x <= 0 && (cur.x < 0 || cur.y < 0)) ? 1 : -1);
-            if (xprod(constraint[0], off) >= 0) {
+            if (utils.xprod(constraint[0], off) >= 0) {
               constraint[0].x = off.x;
               constraint[0].y = off.y;
             }
             off.x = cur.x + ((cur.y <= 0 && (cur.y < 0 || cur.x < 0)) ? 1 : -1);
             off.y = cur.y + ((cur.x >= 0 && (cur.x > 0 || cur.y < 0)) ? 1 : -1);
-            if (xprod(constraint[1], off) <= 0) {
+            if (utils.xprod(constraint[1], off) <= 0) {
               constraint[1].x = off.x;
               constraint[1].y = off.y;
             }
           }
           k1 = k;
           k = nc[k1];
-          if (!cyclic(k, i, k1)) {
+          if (!utils.cyclic(k, i, k1)) {
             break;
           }
         }
         if (foundk === 0) {
-          dk.x = sign(pt[k].x-pt[k1].x);
-          dk.y = sign(pt[k].y-pt[k1].y);
+          dk.x = utils.sign(pt[k].x-pt[k1].x);
+          dk.y = utils.sign(pt[k].y-pt[k1].y);
           cur.x = pt[k1].x - pt[i].x;
           cur.y = pt[k1].y - pt[i].y;
-  
-          a = xprod(constraint[0], cur);
-          b = xprod(constraint[0], dk);
-          c = xprod(constraint[1], cur);
-          d = xprod(constraint[1], dk);
-  
+
+          a = utils.xprod(constraint[0], cur);
+          b = utils.xprod(constraint[0], dk);
+          c = utils.xprod(constraint[1], cur);
+          d = utils.xprod(constraint[1], dk);
+
           j = 10000000;
+
           if (b < 0) {
             j = Math.floor(a / -b);
           }
           if (d > 0) {
             j = Math.min(j, Math.floor(-c / d));
           }
-          pivk[i] = mod(k1+j,n);
+
+          pivk[i] = utils.mod(k1+j,n);
         }
       }
-      
+
       j=pivk[n-1];
       path.lon[n-1]=j;
       for (i=n-2; i>=0; i--) {
-        if (cyclic(i+1,pivk[i],j)) {
+        if (utils.cyclic(i+1,pivk[i],j)) {
           j=pivk[i];
         }
         path.lon[i]=j;
       }
-  
-      for (i=n-1; cyclic(mod(i+1,n),j,path.lon[i]); i--) {
+
+      for (i=n-1; utils.cyclic(utils.mod(i+1,n),j,path.lon[i]); i--) {
         path.lon[i] = j;
       }
     }
-    
+
     function bestPolygon(path) {
-      
+
       function penalty3(path, i, j) {
-        
+
         var n = path.len, pt = path.pt, sums = path.sums;
         var x, y, xy, x2, y2,
           k, a, b, c, s,
@@ -576,7 +345,7 @@ var Potrace = (function() {
           j -= n;
           r = 1;
         }
-        
+
         if (r === 0) {
           x = sums[j+1].x - sums[i].x;
           y = sums[j+1].y - sums[i].y;
@@ -591,23 +360,23 @@ var Potrace = (function() {
           xy = sums[j+1].xy - sums[i].xy + sums[n].xy;
           y2 = sums[j+1].y2 - sums[i].y2 + sums[n].y2;
           k = j+1 - i + n;
-        } 
-      
+        }
+
         px = (pt[i].x + pt[j].x) / 2.0 - pt[0].x;
         py = (pt[i].y + pt[j].y) / 2.0 - pt[0].y;
         ey = (pt[j].x - pt[i].x);
         ex = -(pt[j].y - pt[i].y);
-      
+
         a = ((x2 - 2*x*px) / k + px*px);
         b = ((xy - x*py - y*px) / k + px*py);
         c = ((y2 - 2*y*py) / k + py*py);
-        
+
         s = ex*ex*a + 2*ex*ey*b + ey*ey*c;
-      
+
         return Math.sqrt(s);
       }
-      
-      var i, j, m, k,    
+
+      var i, j, m, k,
       n = path.len,
       pen = new Array(n + 1),
       prev = new Array(n + 1),
@@ -616,11 +385,11 @@ var Potrace = (function() {
       seg0 = new Array (n + 1),
       seg1 = new Array(n + 1),
       thispen, best, c;
-      
+
       for (i=0; i<n; i++) {
-        c = mod(path.lon[mod(i-1,n)]-1,n);
+        c = utils.mod(path.lon[utils.mod(i-1,n)]-1,n);
         if (c == i) {
-          c = mod(i+1,n);
+          c = utils.mod(i+1,n);
         }
         if (c < i) {
           clip0[i] = n;
@@ -628,7 +397,7 @@ var Potrace = (function() {
           clip0[i] = c;
         }
       }
-      
+
       j = 1;
       for (i=0; i<n; i++) {
         while (j <= clip0[i]) {
@@ -636,7 +405,7 @@ var Potrace = (function() {
           j++;
         }
       }
-      
+
       i = 0;
       for (j=0; i<n; j++) {
         seg0[j] = i;
@@ -644,14 +413,14 @@ var Potrace = (function() {
       }
       seg0[j] = n;
       m = j;
-    
+
       i = n;
       for (j=m; j>0; j--) {
         seg1[j] = i;
         i = clip1[i];
       }
       seg1[0] = 0;
-      
+
       pen[0]=0;
       for (j=1; j<=m; j++) {
         for (i=seg1[j]; i<=seg0[j]; i++) {
@@ -668,21 +437,21 @@ var Potrace = (function() {
       }
       path.m = m;
       path.po = new Array(m);
-    
+
       for (i=n, j=m-1; i>0; j--) {
         i = prev[i];
         path.po[j] = i;
       }
     }
-    
+
     function adjustVertices(path) {
-      
+
       function pointslope(path, i, j, ctr, dir) {
-    
+
         var n = path.len, sums = path.sums,
           x, y, x2, xy, y2,
           k, a, b, c, lambda2, l, r=0;
-      
+
         while (j>=n) {
           j-=n;
           r+=1;
@@ -699,26 +468,26 @@ var Potrace = (function() {
           i+=n;
           r+=1;
         }
-        
+
         x = sums[j+1].x-sums[i].x+r*sums[n].x;
         y = sums[j+1].y-sums[i].y+r*sums[n].y;
         x2 = sums[j+1].x2-sums[i].x2+r*sums[n].x2;
         xy = sums[j+1].xy-sums[i].xy+r*sums[n].xy;
         y2 = sums[j+1].y2-sums[i].y2+r*sums[n].y2;
         k = j+1-i+r*n;
-        
+
         ctr.x = x/k;
         ctr.y = y/k;
-      
+
         a = (x2-x*x/k)/k;
         b = (xy-x*y/k)/k;
         c = (y2-y*y/k)/k;
-        
+
         lambda2 = (a+c+Math.sqrt((a-c)*(a-c)+4*b*b))/2;
-      
+
         a -= lambda2;
         c -= lambda2;
-      
+
         if (Math.abs(a) >= Math.abs(c)) {
           l = Math.sqrt(a*a+b*b);
           if (l!==0) {
@@ -733,27 +502,27 @@ var Potrace = (function() {
           }
         }
         if (l===0) {
-          dir.x = dir.y = 0; 
+          dir.x = dir.y = 0;
         }
       }
-      
+
       var m = path.m, po = path.po, n = path.len, pt = path.pt,
         x0 = path.x0, y0 = path.y0,
         ctr = new Array(m), dir = new Array(m),
         q = new Array(m),
         v = new Array(3), d, i, j, k, l,
         s = new Point();
-      
+
       path.curve = new Curve(m);
-  
+
       for (i=0; i<m; i++) {
-        j = po[mod(i+1,m)];
-        j = mod(j-po[i],n)+po[i];
+        j = po[utils.mod(i+1,m)];
+        j = utils.mod(j-po[i],n)+po[i];
         ctr[i] = new Point();
         dir[i] = new Point();
         pointslope(path, po[i], j, ctr[i], dir[i]);
       }
-    
+
       for (i=0; i<m; i++) {
         q[i] = new Quad();
         d = dir[i].x * dir[i].x + dir[i].y * dir[i].y;
@@ -774,32 +543,32 @@ var Potrace = (function() {
           }
         }
       }
-     
+
       var Q, w, dx, dy, det, min, cand, xmin, ymin, z;
       for (i=0; i<m; i++) {
         Q = new Quad();
         w = new Point();
-    
+
         s.x = pt[po[i]].x-x0;
         s.y = pt[po[i]].y-y0;
-    
-        j = mod(i-1,m);
-        
+
+        j = utils.mod(i-1,m);
+
         for (l=0; l<3; l++) {
           for (k=0; k<3; k++) {
             Q.data[l * 3 + k] = q[j].at(l, k) + q[i].at(l, k);
           }
         }
-        
+
         while(1) {
-          
+
           det = Q.at(0, 0)*Q.at(1, 1) - Q.at(0, 1)*Q.at(1, 0);
           if (det !== 0.0) {
             w.x = (-Q.at(0, 2)*Q.at(1, 1) + Q.at(1, 2)*Q.at(0, 1)) / det;
             w.y = ( Q.at(0, 2)*Q.at(1, 0) - Q.at(1, 2)*Q.at(0, 0)) / det;
             break;
           }
-    
+
           if (Q.at(0, 0)>Q.at(1, 1)) {
             v[0] = -Q.at(0, 1);
             v[1] = Q.at(0, 0);
@@ -824,17 +593,17 @@ var Potrace = (function() {
           path.curve.vertex[i] = new Point(w.x+x0, w.y+y0);
           continue;
         }
-    
-        min = quadform(Q, s);
+
+        min = utils.quadform(Q, s);
         xmin = s.x;
         ymin = s.y;
-    
+
         if (Q.at(0, 0) !== 0.0) {
           for (z=0; z<2; z++) {
             w.y = s.y-0.5+z;
             w.x = - (Q.at(0, 1) * w.y + Q.at(0, 2)) / Q.at(0, 0);
             dx = Math.abs(w.x-s.x);
-            cand = quadform(Q, w);
+            cand = utils.quadform(Q, w);
             if (dx <= 0.5 && cand < min) {
               min = cand;
               xmin = w.x;
@@ -842,13 +611,13 @@ var Potrace = (function() {
             }
           }
         }
-  
+
         if (Q.at(1, 1) !== 0.0) {
           for (z=0; z<2; z++) {
             w.x = s.x-0.5+z;
             w.y = - (Q.at(1, 0) * w.x + Q.at(1, 2)) / Q.at(1, 1);
             dy = Math.abs(w.y-s.y);
-            cand = quadform(Q, w);
+            cand = utils.quadform(Q, w);
             if (dy <= 0.5 && cand < min) {
               min = cand;
               xmin = w.x;
@@ -856,12 +625,12 @@ var Potrace = (function() {
             }
           }
         }
-  
+
         for (l=0; l<2; l++) {
           for (k=0; k<2; k++) {
             w.x = s.x-0.5+l;
             w.y = s.y-0.5+k;
-            cand = quadform(Q, w);
+            cand = utils.quadform(Q, w);
             if (cand < min) {
               min = cand;
               xmin = w.x;
@@ -869,35 +638,35 @@ var Potrace = (function() {
             }
           }
         }
-    
+
         path.curve.vertex[i] = new Point(xmin + x0, ymin + y0);
       }
     }
-    
+
     function reverse(path) {
       var curve = path.curve, m = curve.n, v = curve.vertex, i, j, tmp;
-    
+
       for (i=0, j=m-1; i<j; i++, j--) {
         tmp = v[i];
         v[i] = v[j];
         v[j] = tmp;
       }
     }
-    
+
     function smooth(path) {
       var m = path.curve.n, curve = path.curve;
 
       var i, j, k, dd, denom, alpha,
         p2, p3, p4;
-    
+
       for (i=0; i<m; i++) {
-        j = mod(i+1, m);
-        k = mod(i+2, m);
-        p4 = interval(1/2.0, curve.vertex[k], curve.vertex[j]);
-    
-        denom = ddenom(curve.vertex[i], curve.vertex[k]);
+        j = utils.mod(i+1, m);
+        k = utils.mod(i+2, m);
+        p4 = utils.interval(1/2.0, curve.vertex[k], curve.vertex[j]);
+
+        denom = utils.ddenom(curve.vertex[i], curve.vertex[k]);
         if (denom !== 0.0) {
-          dd = dpara(curve.vertex[i], curve.vertex[j], curve.vertex[k]) / denom;
+          dd = utils.dpara(curve.vertex[i], curve.vertex[j], curve.vertex[k]) / denom;
           dd = Math.abs(dd);
           alpha = dd>1 ? (1 - 1.0/dd) : 0;
           alpha = alpha / 0.75;
@@ -905,8 +674,8 @@ var Potrace = (function() {
           alpha = 4/3.0;
         }
         curve.alpha0[j] = alpha;
-    
-        if (alpha >= info.alphamax) { 
+
+        if (alpha >= self._params.alphamax) {
           curve.tag[j] = "CORNER";
           curve.c[3 * j + 1] = curve.vertex[j];
           curve.c[3 * j + 2] = p4;
@@ -916,142 +685,135 @@ var Potrace = (function() {
           } else if (alpha > 1) {
             alpha = 1;
           }
-          p2 = interval(0.5+0.5*alpha, curve.vertex[i], curve.vertex[j]);
-          p3 = interval(0.5+0.5*alpha, curve.vertex[k], curve.vertex[j]);
+          p2 = utils.interval(0.5+0.5*alpha, curve.vertex[i], curve.vertex[j]);
+          p3 = utils.interval(0.5+0.5*alpha, curve.vertex[k], curve.vertex[j]);
           curve.tag[j] = "CURVE";
           curve.c[3 * j + 0] = p2;
           curve.c[3 * j + 1] = p3;
           curve.c[3 * j + 2] = p4;
         }
-        curve.alpha[j] = alpha;  
+        curve.alpha[j] = alpha;
         curve.beta[j] = 0.5;
       }
       curve.alphacurve = 1;
     }
-    
+
     function optiCurve(path) {
-      function Opti(){
-        this.pen = 0;
-        this.c = [new Point(), new Point()];
-        this.t = 0;
-        this.s = 0;
-        this.alpha = 0;
-      }
-      
+
       function opti_penalty(path, i, j, res, opttolerance, convc, areac) {
-        var m = path.curve.n, curve = path.curve, vertex = curve.vertex, 
+        var m = path.curve.n, curve = path.curve, vertex = curve.vertex,
           k, k1, k2, conv, i1,
           area, alpha, d, d1, d2,
           p0, p1, p2, p3, pt,
           A, R, A1, A2, A3, A4,
           s, t;
-      
+
         if (i==j) {
           return 1;
         }
-      
+
         k = i;
-        i1 = mod(i+1, m);
-        k1 = mod(k+1, m);
+        i1 = utils.mod(i+1, m);
+        k1 = utils.mod(k+1, m);
         conv = convc[k1];
         if (conv === 0) {
           return 1;
         }
-        d = ddist(vertex[i], vertex[i1]);
+        d = utils.ddist(vertex[i], vertex[i1]);
         for (k=k1; k!=j; k=k1) {
-          k1 = mod(k+1, m);
-          k2 = mod(k+2, m);
+          k1 = utils.mod(k+1, m);
+          k2 = utils.mod(k+2, m);
           if (convc[k1] != conv) {
             return 1;
           }
-          if (sign(cprod(vertex[i], vertex[i1], vertex[k1], vertex[k2])) !=
+          if (utils.sign(utils.cprod(vertex[i], vertex[i1], vertex[k1], vertex[k2])) !=
               conv) {
             return 1;
           }
-          if (iprod1(vertex[i], vertex[i1], vertex[k1], vertex[k2]) <
-              d * ddist(vertex[k1], vertex[k2]) * -0.999847695156) {
+          if (utils.iprod1(vertex[i], vertex[i1], vertex[k1], vertex[k2]) <
+              d * utils.ddist(vertex[k1], vertex[k2]) * -0.999847695156) {
             return 1;
           }
         }
-    
-        p0 = curve.c[mod(i,m) * 3 + 2].copy();
-        p1 = vertex[mod(i+1,m)].copy();
-        p2 = vertex[mod(j,m)].copy();
-        p3 = curve.c[mod(j,m) * 3 + 2].copy();
-      
+
+        p0 = curve.c[utils.mod(i,m) * 3 + 2].copy();
+        p1 = vertex[utils.mod(i+1,m)].copy();
+        p2 = vertex[utils.mod(j,m)].copy();
+        p3 = curve.c[utils.mod(j,m) * 3 + 2].copy();
+
         area = areac[j] - areac[i];
-        area -= dpara(vertex[0], curve.c[i * 3 + 2], curve.c[j * 3 + 2])/2;
+        area -= utils.dpara(vertex[0], curve.c[i * 3 + 2], curve.c[j * 3 + 2])/2;
         if (i>=j) {
           area += areac[m];
         }
-      
-        A1 = dpara(p0, p1, p2);
-        A2 = dpara(p0, p1, p3);
-        A3 = dpara(p0, p2, p3);
-  
-        A4 = A1+A3-A2;    
-        
+
+        A1 = utils.dpara(p0, p1, p2);
+        A2 = utils.dpara(p0, p1, p3);
+        A3 = utils.dpara(p0, p2, p3);
+
+        A4 = A1+A3-A2;
+
         if (A2 == A1) {
           return 1;
         }
-      
+
         t = A3/(A3-A4);
         s = A2/(A2-A1);
         A = A2 * t / 2.0;
-        
+
         if (A === 0.0) {
           return 1;
         }
-      
+
         R = area / A;
         alpha = 2 - Math.sqrt(4 - R / 0.3);
-      
-        res.c[0] = interval(t * alpha, p0, p1);
-        res.c[1] = interval(s * alpha, p3, p2);
+
+        res.c[0] = utils.interval(t * alpha, p0, p1);
+        res.c[1] = utils.interval(s * alpha, p3, p2);
         res.alpha = alpha;
         res.t = t;
         res.s = s;
-      
+
         p1 = res.c[0].copy();
-        p2 = res.c[1].copy(); 
-      
+        p2 = res.c[1].copy();
+
         res.pen = 0;
-      
-        for (k=mod(i+1,m); k!=j; k=k1) {
-          k1 = mod(k+1,m);
-          t = tangent(p0, p1, p2, p3, vertex[k], vertex[k1]);
+
+        for (k=utils.mod(i+1,m); k!=j; k=k1) {
+          k1 = utils.mod(k+1,m);
+          t = utils.tangent(p0, p1, p2, p3, vertex[k], vertex[k1]);
           if (t<-0.5) {
             return 1;
           }
-          pt = bezier(t, p0, p1, p2, p3);
-          d = ddist(vertex[k], vertex[k1]);
+          pt = utils.bezier(t, p0, p1, p2, p3);
+          d = utils.ddist(vertex[k], vertex[k1]);
           if (d === 0.0) {
             return 1;
           }
-          d1 = dpara(vertex[k], vertex[k1], pt) / d;
+          d1 = utils.dpara(vertex[k], vertex[k1], pt) / d;
           if (Math.abs(d1) > opttolerance) {
             return 1;
           }
-          if (iprod(vertex[k], vertex[k1], pt) < 0 ||
-              iprod(vertex[k1], vertex[k], pt) < 0) {
+          if (utils.iprod(vertex[k], vertex[k1], pt) < 0 ||
+              utils.iprod(vertex[k1], vertex[k], pt) < 0) {
             return 1;
           }
           res.pen += d1 * d1;
         }
-      
+
         for (k=i; k!=j; k=k1) {
-          k1 = mod(k+1,m);
-          t = tangent(p0, p1, p2, p3, curve.c[k * 3 + 2], curve.c[k1 * 3 + 2]);
+          k1 = utils.mod(k+1,m);
+          t = utils.tangent(p0, p1, p2, p3, curve.c[k * 3 + 2], curve.c[k1 * 3 + 2]);
           if (t<-0.5) {
             return 1;
           }
-          pt = bezier(t, p0, p1, p2, p3);
-          d = ddist(curve.c[k * 3 + 2], curve.c[k1 * 3 + 2]);
+          pt = utils.bezier(t, p0, p1, p2, p3);
+          d = utils.ddist(curve.c[k * 3 + 2], curve.c[k1 * 3 + 2]);
           if (d === 0.0) {
             return 1;
           }
-          d1 = dpara(curve.c[k * 3 + 2], curve.c[k1 * 3 + 2], pt) / d;
-          d2 = dpara(curve.c[k * 3 + 2], curve.c[k1 * 3 + 2], vertex[k1]) / d;
+          d1 = utils.dpara(curve.c[k * 3 + 2], curve.c[k1 * 3 + 2], pt) / d;
+          d2 = utils.dpara(curve.c[k * 3 + 2], curve.c[k1 * 3 + 2], vertex[k1]) / d;
           d2 *= 0.75 * curve.alpha[k1];
           if (d2 < 0) {
             d1 = -d1;
@@ -1064,56 +826,56 @@ var Potrace = (function() {
             res.pen += (d1 - d2) * (d1 - d2);
           }
         }
-      
+
         return 0;
       }
-    
-      var curve = path.curve, m = curve.n, vert = curve.vertex, 
-        pt = new Array(m + 1),
-        pen = new Array(m + 1),
-        len = new Array(m + 1),
-        opt = new Array(m + 1),
-        om, i,j,r,
-        o = new Opti(), p0,
-        i1, area, alpha, ocurve,
-        s, t;
-      
+
+      var curve = path.curve, m = curve.n, vert = curve.vertex,
+          pt = new Array(m + 1),
+          pen = new Array(m + 1),
+          len = new Array(m + 1),
+          opt = new Array(m + 1),
+          om, i,j,r,
+          o = new Opti(), p0,
+          i1, area, alpha, ocurve,
+          s, t;
+
       var convc = new Array(m), areac = new Array(m + 1);
-      
+
       for (i=0; i<m; i++) {
         if (curve.tag[i] == "CURVE") {
-          convc[i] = sign(dpara(vert[mod(i-1,m)], vert[i], vert[mod(i+1,m)]));
+          convc[i] = utils.sign(utils.dpara(vert[utils.mod(i-1,m)], vert[i], vert[utils.mod(i+1,m)]));
         } else {
           convc[i] = 0;
         }
       }
-    
+
       area = 0.0;
       areac[0] = 0.0;
       p0 = curve.vertex[0];
       for (i=0; i<m; i++) {
-        i1 = mod(i+1, m);
+        i1 = utils.mod(i+1, m);
         if (curve.tag[i1] == "CURVE") {
           alpha = curve.alpha[i1];
           area += 0.3 * alpha * (4-alpha) *
-              dpara(curve.c[i * 3 + 2], vert[i1], curve.c[i1 * 3 + 2])/2;
-          area += dpara(p0, curve.c[i * 3 + 2], curve.c[i1 * 3 + 2])/2;
+              utils.dpara(curve.c[i * 3 + 2], vert[i1], curve.c[i1 * 3 + 2])/2;
+          area += utils.dpara(p0, curve.c[i * 3 + 2], curve.c[i1 * 3 + 2])/2;
         }
         areac[i+1] = area;
       }
-    
+
       pt[0] = -1;
       pen[0] = 0;
       len[0] = 0;
-    
-    
+
+
       for (j=1; j<=m; j++) {
         pt[j] = j-1;
         pen[j] = pen[j-1];
         len[j] = len[j-1]+1;
-    
+
         for (i=j-2; i>=0; i--) {
-          r = opti_penalty(path, i, mod(j,m), o, info.opttolerance, convc, 
+          r = opti_penalty(path, i, utils.mod(j,m), o, self._params.opttolerance, convc,
               areac);
           if (r) {
             break;
@@ -1132,26 +894,26 @@ var Potrace = (function() {
       ocurve = new Curve(om);
       s = new Array(om);
       t = new Array(om);
-    
+
       j = m;
       for (i=om-1; i>=0; i--) {
         if (pt[j]==j-1) {
-          ocurve.tag[i]     = curve.tag[mod(j,m)];
-          ocurve.c[i * 3 + 0]    = curve.c[mod(j,m) * 3 + 0];
-          ocurve.c[i * 3 + 1]    = curve.c[mod(j,m) * 3 + 1];
-          ocurve.c[i * 3 + 2]    = curve.c[mod(j,m) * 3 + 2];
-          ocurve.vertex[i]  = curve.vertex[mod(j,m)];
-          ocurve.alpha[i]   = curve.alpha[mod(j,m)];
-          ocurve.alpha0[i]  = curve.alpha0[mod(j,m)];
-          ocurve.beta[i]    = curve.beta[mod(j,m)];
+          ocurve.tag[i]     = curve.tag[utils.mod(j,m)];
+          ocurve.c[i * 3 + 0]    = curve.c[utils.mod(j,m) * 3 + 0];
+          ocurve.c[i * 3 + 1]    = curve.c[utils.mod(j,m) * 3 + 1];
+          ocurve.c[i * 3 + 2]    = curve.c[utils.mod(j,m) * 3 + 2];
+          ocurve.vertex[i]  = curve.vertex[utils.mod(j,m)];
+          ocurve.alpha[i]   = curve.alpha[utils.mod(j,m)];
+          ocurve.alpha0[i]  = curve.alpha0[utils.mod(j,m)];
+          ocurve.beta[i]    = curve.beta[utils.mod(j,m)];
           s[i] = t[i] = 1.0;
         } else {
           ocurve.tag[i] = "CURVE";
           ocurve.c[i * 3 + 0] = opt[j].c[0];
           ocurve.c[i * 3 + 1] = opt[j].c[1];
-          ocurve.c[i * 3 + 2] = curve.c[mod(j,m) * 3 + 2];
-          ocurve.vertex[i] = interval(opt[j].s, curve.c[mod(j,m) * 3 + 2],
-                                       vert[mod(j,m)]);
+          ocurve.c[i * 3 + 2] = curve.c[utils.mod(j,m) * 3 + 2];
+          ocurve.vertex[i] = utils.interval(opt[j].s, curve.c[utils.mod(j,m) * 3 + 2],
+                                       vert[utils.mod(j,m)]);
           ocurve.alpha[i] = opt[j].alpha;
           ocurve.alpha0[i] = opt[j].alpha;
           s[i] = opt[j].s;
@@ -1159,121 +921,116 @@ var Potrace = (function() {
         }
         j = pt[j];
       }
-    
+
       for (i=0; i<om; i++) {
-        i1 = mod(i+1,om);
+        i1 = utils.mod(i+1,om);
         ocurve.beta[i] = s[i] / (s[i] + t[i1]);
       }
       ocurve.alphacurve = 1;
       path.curve = ocurve;
     }
-    
-    for (var i = 0; i < pathlist.length; i++) {
-      var path = pathlist[i];
+
+    for (var i = 0; i < this._pathlist.length; i++) {
+      var path = this._pathlist[i];
       calcSums(path);
       calcLon(path);
       bestPolygon(path);
       adjustVertices(path);
-      
+
       if (path.sign === "-") {
         reverse(path);
       }
-      
+
       smooth(path);
-      
-      if (info.optcurve) {
+
+      if (self._params.optcurve) {
         optiCurve(path);
       }
     }
-  
-  }
+  },
 
-  function process(c) {
-    if (c) {
-      callback = c;
+  loadImage: function(target, cb) {
+    var self = this;
+    var blackLevel = self._params.blacklevel;
+
+    this._imageLoading = true;
+
+    if (this._imageLoading || this._imageLoaded) {
+      this._imageLoaded = false;
     }
-    if (!info.isReady) {
-      setTimeout(process, 100);
-      return;
+
+    Jimp.read(target, function(err, img){
+      if (err) return cb(err);
+
+      var bitmap = new Bitmap(img.bitmap.width, img.bitmap.height);
+      var pixels = img.bitmap.data;
+
+      img.scan(0, 0, img.bitmap.width, img.bitmap.height, function(x, y, idx) {
+        var luminance = utils.luminance(pixels[idx], pixels[idx + 1], pixels[idx + 2]);
+        bitmap.data[idx/4] = luminance < blackLevel ? 1 : 0;
+      });
+
+      self._bitmap = bitmap;
+      self._imageLoaded = true;
+
+      cb(null);
+    });
+  },
+
+  process: function(callback) {
+    if (this._processed) {
+      return callback();
     }
-    bmToPathlist();
-    processPath();
+
+    this._bmToPathlist();
+    this._processPath();
+    this._processed = true;
+
     callback();
-    callback = null;
-  }
+	},
 
-  function clear() {
-    bm = null;
-    pathlist = [];
-    callback = null;
-    info.isReady = false;
-  }
-  
-  function getSVG(size, opt_type) {
-  
-    function path(curve) {
+	setParameter: function(newParams) {
+    var key;
+
+		for (key in this._params) {
+			if (this._params.hasOwnProperty(key) && newParams.hasOwnProperty(key)) {
+				this._params[key] = newParams[key];
+        this._processed = false;
+			}
+		}
+	},
+
+	/**
+	 * Generates SVG
+	 *
+	 * @param scale
+	 * @param useCurves
+	 */
+	getSVG: function(scale, useCurves) {
+		scale = scale || 1;
+		useCurves = useCurves === true;
+
+		if (!this._processed) {
+			throw new Error('Image needs to be processed first.');
+		}
+
+    var svg = '<svg id="svg" version="1.1" ' +
+      'width="' + (this._bitmap.w * scale) + '" ' +
+      'height="' + (this._bitmap.h * scale) + '" ' +
+      'xmlns="http://www.w3.org/2000/svg"><path d="';
     
-      function bezier(i) {
-        var b = 'C ' + (curve.c[i * 3 + 0].x * size).toFixed(3) + ' ' +
-            (curve.c[i * 3 + 0].y * size).toFixed(3) + ',';
-        b += (curve.c[i * 3 + 1].x * size).toFixed(3) + ' ' +
-            (curve.c[i * 3 + 1].y * size).toFixed(3) + ',';
-        b += (curve.c[i * 3 + 2].x * size).toFixed(3) + ' ' +
-            (curve.c[i * 3 + 2].y * size).toFixed(3) + ' ';
-        return b;
-      }
-    
-      function segment(i) {
-        var s = 'L ' + (curve.c[i * 3 + 1].x * size).toFixed(3) + ' ' +
-            (curve.c[i * 3 + 1].y * size).toFixed(3) + ' ';
-        s += (curve.c[i * 3 + 2].x * size).toFixed(3) + ' ' +
-            (curve.c[i * 3 + 2].y * size).toFixed(3) + ' ';
-        return s;
-      }
+    this._pathlist.forEach(function(path) {
+      svg += utils.renderCurve(path.curve, scale);
+    });
 
-      var n = curve.n, i;
-      var p = 'M' + (curve.c[(n - 1) * 3 + 2].x * size).toFixed(3) +
-          ' ' + (curve.c[(n - 1) * 3 + 2].y * size).toFixed(3) + ' ';
-      for (i = 0; i < n; i++) {
-        if (curve.tag[i] === "CURVE") {
-          p += bezier(i);
-        } else if (curve.tag[i] === "CORNER") {
-          p += segment(i);
-        }
-      }
-      //p += 
-      return p;
-    }
-
-    var w = bm.w * size, h = bm.h * size,
-      len = pathlist.length, c, i, strokec, fillc, fillrule;
-
-    var svg = '<svg id="svg" version="1.1" width="' + w + '" height="' + h +
-        '" xmlns="http://www.w3.org/2000/svg">';
-    svg += '<path d="';
-    for (i = 0; i < len; i++) {
-      c = pathlist[i].curve;
-      svg += path(c);
-    }
-    if (opt_type === "curve") {
-      strokec = "black";
-      fillc = "none";
-      fillrule = '';
+    if (useCurves) {
+      svg += '" stroke="black" fill="none"/></svg>';
     } else {
-      strokec = "none";
-      fillc = "black";
-      fillrule = ' fill-rule="evenodd"';
+      svg += '" stroke="none" fill="black" fill-rule="evenodd"/></svg>';
     }
-    svg += '" stroke="' + strokec + '" fill="' + fillc + '"' + fillrule + '/></svg>';
-    return svg;
-  }
-  
-  return{
-    loadImage: loadImage,
-    setParameter: setParameter,
-    process: process,
-    getSVG: getSVG
-  };
-})();
 
-module.exports = Potrace;
+    return svg;
+	}
+};
+
+module.exports = Potrace2;

--- a/lib/Potrace.js
+++ b/lib/Potrace.js
@@ -993,6 +993,7 @@ Potrace.prototype = {
 
       self._luminanceData = bitmap;
       self._imageLoaded = true;
+      self._currentTarget = null;
 
       callback(null);
     });

--- a/lib/Potrace.js
+++ b/lib/Potrace.js
@@ -983,12 +983,15 @@ Potrace.prototype = {
         return callback(new Error('loadImage method was used with another source since last time'));
       }
 
+      // Creating new image with white background and copying loaded image onto it
+      var whiteImg = new Jimp(img.bitmap.width, img.bitmap.height, 0xFFFFFFFF);
+      whiteImg.composite(img, 0, 0);
+
       var bitmap = new Bitmap(img.bitmap.width, img.bitmap.height);
-      var pixels = img.bitmap.data;
+      var pixels = whiteImg.bitmap.data;
 
       img.scan(0, 0, img.bitmap.width, img.bitmap.height, function(x, y, idx) {
-        var luminance = utils.luminance(pixels[idx], pixels[idx + 1], pixels[idx + 2]);
-        bitmap.data[idx/4] = luminance;
+        bitmap.data[idx/4] = utils.luminance(pixels[idx], pixels[idx + 1], pixels[idx + 2]);
       });
 
       self._luminanceData = bitmap;

--- a/lib/Potrace.js
+++ b/lib/Potrace.js
@@ -24,23 +24,23 @@ var SUPPORTED_TURNPOLICY_VALUES = [
 ];
 
 function Potrace () {
-	this._bitmap = null;
-	this._pathlist = [];
+  this._bitmap = null;
+  this._pathlist = [];
 
-	this._imageLoading = false;
-	this._imageLoaded = false;
-	this._processed = false;
+  this._imageLoading = false;
+  this._imageLoaded = false;
+  this._processed = false;
 
   this._currentTarget = null;
 
-	this._params = {
-		turnpolicy: "minority",
-		turdsize: 2,
-		optcurve: true,
-		alphamax: 1,
-		opttolerance: 0.2,
-		blacklevel: 128
-	}
+  this._params = {
+    turnpolicy: "minority",
+    turdsize: 2,
+    optcurve: true,
+    alphamax: 1,
+    opttolerance: 0.2,
+    blacklevel: 128
+  }
 }
 
 Potrace.TURNPOLICY_BLACK = TURNPOLICY_BLACK;
@@ -57,7 +57,7 @@ Potrace.prototype = {
         currentPoint = new Point(0, 0),
         path;
 
-	  /**
+    /**
      * finds next black pixel of the image
      *
      * @param point
@@ -954,7 +954,7 @@ Potrace.prototype = {
     }
   },
 
-	/**
+  /**
    * Reads given image. Uses Jimp under the hood, so target can be whatever Jimp can take
    *
    * @param {*} target
@@ -993,7 +993,7 @@ Potrace.prototype = {
     });
   },
 
-	/**
+  /**
    * Processing loaded image
    *
    * @param {Function} [callback] - optional callback which is called when image is processed. However, this method is synchronous, so callback is unnecessary
@@ -1013,7 +1013,7 @@ Potrace.prototype = {
     this._processed = true;
 
     callback();
-	},
+  },
 
   /**
    * Sets algorithm parameters
@@ -1026,18 +1026,18 @@ Potrace.prototype = {
    * @param {Number}  [newParams.opttolerance] - curve optimization tolerance (default 0.2)
    * @param {Number}  [newParams.blacklevel]   - treshold below which color is considered black (0..255, default 128)
    */
-	setParameter: function(newParams) {
+  setParameter: function(newParams) {
     var key;
 
     this._validateParameters(newParams);
 
-		for (key in this._params) {
-			if (this._params.hasOwnProperty(key) && newParams.hasOwnProperty(key)) {
-				this._params[key] = newParams[key];
+    for (key in this._params) {
+      if (this._params.hasOwnProperty(key) && newParams.hasOwnProperty(key)) {
+        this._params[key] = newParams[key];
         this._processed = false;
-			}
-		}
-	},
+      }
+    }
+  },
 
   /**
    * Generates SVG image
@@ -1045,18 +1045,18 @@ Potrace.prototype = {
    * @param {Number} [scale]
    * @param {Boolean} [useCurves]
    * @returns {String}
-	 */
-	getSVG: function(scale, useCurves) {
-		scale = scale || 1;
-		useCurves = useCurves === true;
+   */
+  getSVG: function(scale, useCurves) {
+    scale = scale || 1;
+    useCurves = useCurves === true;
 
     if (!this._imageLoaded) {
       throw new Error('Image should be loaded first');
     }
 
-		if (!this._processed) {
-			throw new Error('Image needs to be processed first.');
-		}
+    if (!this._processed) {
+      throw new Error('Image needs to be processed first.');
+    }
 
     var svg = '<svg id="svg" version="1.1" ' +
       'width="' + (this._bitmap.w * scale) + '" ' +
@@ -1074,7 +1074,7 @@ Potrace.prototype = {
     }
 
     return svg;
-	}
+  }
 };
 
 module.exports = Potrace;

--- a/lib/Potrace.js
+++ b/lib/Potrace.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 var Jimp = require('jimp');
 var Bitmap = require('./types/Bitmap');
 var Curve = require('./types/Curve');
@@ -52,6 +51,7 @@ function Potrace2 () {
 	this._imageLoading = false;
 	this._imageLoaded = false;
 	this._processed = false;
+  this._currentTarget = null;
 
 	this._params = {
 		turnpolicy: "minority",
@@ -953,6 +953,7 @@ Potrace2.prototype = {
     var self = this;
     var blackLevel = self._params.blacklevel;
 
+    this._currentTarget = target;
     this._imageLoading = true;
 
     if (this._imageLoading || this._imageLoaded) {
@@ -961,6 +962,10 @@ Potrace2.prototype = {
 
     Jimp.read(target, function(err, img){
       if (err) return cb(err);
+
+      if (self._currentTarget !== target) {
+        return cb(new Error('loadImage method was used with another source since last time'));
+      }
 
       var bitmap = new Bitmap(img.bitmap.width, img.bitmap.height);
       var pixels = img.bitmap.data;

--- a/lib/Potrace.js
+++ b/lib/Potrace.js
@@ -24,7 +24,7 @@ var SUPPORTED_TURNPOLICY_VALUES = [
 ];
 
 function Potrace () {
-  this._bitmap = null;
+  this._luminanceData = null;
   this._pathlist = [];
 
   this._imageLoading = false;
@@ -34,7 +34,7 @@ function Potrace () {
   this._currentTarget = null;
 
   this._params = {
-    turnpolicy: "minority",
+    turnpolicy: TURNPOLICY_MINORITY,
     turdsize: 2,
     optcurve: true,
     alphamax: 1,
@@ -53,7 +53,8 @@ Potrace.TURNPOLICY_MAJORITY = TURNPOLICY_MAJORITY;
 Potrace.prototype = {
   _bmToPathlist: function() {
     var self = this,
-        bitmap = this._bitmap.copy(),
+        threshold = this._params.blacklevel,
+        blackMap = this._luminanceData.copy(function(lum) { return lum < threshold ? 1 : 0; }),
         currentPoint = new Point(0, 0),
         path;
 
@@ -64,13 +65,13 @@ Potrace.prototype = {
      * @returns {boolean|*}
      */
     function findNext(point) {
-      var i = bitmap.w * point.y + point.x;
+      var i = blackMap.pointToIndex(point);
 
-      while (i < bitmap.size && bitmap.data[i] !== 1) {
+      while (i < blackMap.size && blackMap.data[i] !== 1) {
         i++;
       }
 
-      return i < bitmap.size && bitmap.index(i);
+      return i < blackMap.size && blackMap.indexToPoint(i);
     }
 
     function majority(x, y) {
@@ -79,10 +80,10 @@ Potrace.prototype = {
       for (i = 2; i < 5; i++) {
         ct = 0;
         for (a = -i + 1; a <= i - 1; a++) {
-          ct += bitmap.at(x + a, y + i - 1) ? 1 : -1;
-          ct += bitmap.at(x + i - 1, y + a - 1) ? 1 : -1;
-          ct += bitmap.at(x + a - 1, y - i) ? 1 : -1;
-          ct += bitmap.at(x - i, y + a) ? 1 : -1;
+          ct += blackMap.getValueAt(x + a, y + i - 1) ? 1 : -1;
+          ct += blackMap.getValueAt(x + i - 1, y + a - 1) ? 1 : -1;
+          ct += blackMap.getValueAt(x + a - 1, y - i) ? 1 : -1;
+          ct += blackMap.getValueAt(x - i, y + a) ? 1 : -1;
         }
 
         if (ct > 0) {
@@ -102,7 +103,7 @@ Potrace.prototype = {
           diry = 1,
           tmp;
 
-      path.sign = bitmap.at(point.x, point.y) ? "+" : "-";
+      path.sign = blackMap.getValueAt(point.x, point.y) ? "+" : "-";
 
       while (1) {
         path.pt.push(new Point(x, y));
@@ -123,8 +124,8 @@ Potrace.prototype = {
         if (x === point.x && y === point.y)
           break;
 
-        var l = bitmap.at(x + (dirx + diry - 1 ) / 2, y + (diry - dirx - 1) / 2);
-        var r = bitmap.at(x + (dirx - diry - 1) / 2, y + (diry + dirx - 1) / 2);
+        var l = blackMap.getValueAt(x + (dirx + diry - 1 ) / 2, y + (diry - dirx - 1) / 2);
+        var r = blackMap.getValueAt(x + (dirx - diry - 1) / 2, y + (diry + dirx - 1) / 2);
 
         if (r && !l) {
           if (self._params.turnpolicy === "right" ||
@@ -156,7 +157,8 @@ Potrace.prototype = {
     function xorPath(path){
       var y1 = path.pt[0].y,
         len = path.len,
-        x, y, maxX, minY, i, j;
+        x, y, maxX, minY, i, j,
+        indx;
 
       for (i = 1; i < len; i++) {
         x = path.pt[i].x;
@@ -166,7 +168,8 @@ Potrace.prototype = {
           minY = y1 < y ? y1 : y;
           maxX = path.maxX;
           for (j = x; j < maxX; j++) {
-            bitmap.flip(j, minY);
+            indx = blackMap.pointToIndex(j, minY);
+            blackMap.data[indx] = blackMap.data[indx] ? 0 : 1;
           }
           y1 = y;
         }
@@ -962,7 +965,6 @@ Potrace.prototype = {
    */
   loadImage: function(target, callback) {
     var self = this;
-    var blackLevel = self._params.blacklevel;
 
     this._currentTarget = target;
     this._imageLoading = true;
@@ -983,10 +985,10 @@ Potrace.prototype = {
 
       img.scan(0, 0, img.bitmap.width, img.bitmap.height, function(x, y, idx) {
         var luminance = utils.luminance(pixels[idx], pixels[idx + 1], pixels[idx + 2]);
-        bitmap.data[idx/4] = luminance < blackLevel ? 1 : 0;
+        bitmap.data[idx/4] = luminance;
       });
 
-      self._bitmap = bitmap;
+      self._luminanceData = bitmap;
       self._imageLoaded = true;
 
       callback(null);
@@ -1059,8 +1061,8 @@ Potrace.prototype = {
     }
 
     var svg = '<svg id="svg" version="1.1" ' +
-      'width="' + (this._bitmap.w * scale) + '" ' +
-      'height="' + (this._bitmap.h * scale) + '" ' +
+      'width="' + (this._luminanceData.width * scale) + '" ' +
+      'height="' + (this._luminanceData.height * scale) + '" ' +
       'xmlns="http://www.w3.org/2000/svg"><path d="';
     
     this._pathlist.forEach(function(path) {

--- a/lib/Potrace.js
+++ b/lib/Potrace.js
@@ -176,6 +176,9 @@ Potrace.prototype = {
       }
     }
 
+    // Clear path list
+    this._pathlist = [];
+
     while (currentPoint = findNext(currentPoint)) {
       path = findPath(currentPoint);
       xorPath(path);

--- a/lib/Potrace.js
+++ b/lib/Potrace.js
@@ -976,10 +976,16 @@ Potrace.prototype = {
       this._imageLoaded = false;
     }
 
-    Jimp.read(target, function(err, img){
+    Jimp.read(target, function(err, img) {
+      var targetHasChanged = self._currentTarget !== target;
+
+      if (!targetHasChanged) {
+        self._currentTarget = null;
+      }
+
       if (err) return callback(err);
 
-      if (self._currentTarget !== target) {
+      if (targetHasChanged) {
         return callback(new Error('loadImage method was used with another source since last time'));
       }
 
@@ -996,7 +1002,6 @@ Potrace.prototype = {
 
       self._luminanceData = bitmap;
       self._imageLoaded = true;
-      self._currentTarget = null;
 
       callback(null);
     });

--- a/lib/Potrace.js
+++ b/lib/Potrace.js
@@ -11,46 +11,26 @@ var Opti = require('./types/Opti');
 
 var utils = require('./utils');
 
-/*
- * A javascript port of Potrace (http://potrace.sourceforge.net).
- * Converted for use outside of the browser, such as NodeJS.
- *
- * Licensed under the GPL
- *
- * Usage
- *   loadImage(file) : load image from File API or URL
- *     input color/grayscale image is simply converted to binary image. no pre-
- *     process is performed.
- *
- *   setParameter({para1: value, ...}) : set parameters
- *     parameters:
- *        turnpolicy ("black" / "white" / "left" / "right" / "minority" / "majority")
- *          how to resolve ambiguities in path decomposition. (default: "minority")
- *        turdsize
- *          suppress speckles of up to this size (default: 2)
- *        optcurve (true / false)
- *          turn on/off curve optimization (default: true)
- *        alphamax
- *          corner threshold parameter (default: 1)
- *        opttolerance
- *          curve optimization tolerance (default: 0.2)
- *        blacklevel (0-255)
- *          below this value of brightness a pixel is considered black (default: 128)
- *
- *   process(callback) : wait for the image be loaded, then run potrace algorithm,
- *                       then call callback function.
- *
- *   getSVG(size, opt_type) : return a string of generated SVG image.
- *                                    result_image_size = original_image_size * size
- *                                    optional parameter opt_type can be "curve"
- */
-function Potrace2 () {
+var TURNPOLICY_BLACK = 'black';
+var TURNPOLICY_WHITE = 'white';
+var TURNPOLICY_LEFT = 'left';
+var TURNPOLICY_RIGHT = 'right';
+var TURNPOLICY_MINORITY = 'minority';
+var TURNPOLICY_MAJORITY = 'majority';
+
+var SUPPORTED_TURNPOLICY_VALUES = [
+  TURNPOLICY_BLACK, TURNPOLICY_WHITE, TURNPOLICY_LEFT,
+  TURNPOLICY_RIGHT, TURNPOLICY_MINORITY, TURNPOLICY_MAJORITY
+];
+
+function Potrace () {
 	this._bitmap = null;
 	this._pathlist = [];
 
 	this._imageLoading = false;
 	this._imageLoaded = false;
 	this._processed = false;
+
   this._currentTarget = null;
 
 	this._params = {
@@ -63,7 +43,14 @@ function Potrace2 () {
 	}
 }
 
-Potrace2.prototype = {
+Potrace.TURNPOLICY_BLACK = TURNPOLICY_BLACK;
+Potrace.TURNPOLICY_WHITE = TURNPOLICY_WHITE;
+Potrace.TURNPOLICY_LEFT = TURNPOLICY_LEFT;
+Potrace.TURNPOLICY_RIGHT = TURNPOLICY_RIGHT;
+Potrace.TURNPOLICY_MINORITY = TURNPOLICY_MINORITY;
+Potrace.TURNPOLICY_MAJORITY = TURNPOLICY_MAJORITY;
+
+Potrace.prototype = {
   _bmToPathlist: function() {
     var self = this,
         bitmap = this._bitmap.copy(),
@@ -949,7 +936,31 @@ Potrace2.prototype = {
     }
   },
 
-  loadImage: function(target, cb) {
+  _validateParameters: function(params) {
+    if (params && params.turnpolicy && SUPPORTED_TURNPOLICY_VALUES.indexOf(params.turnpolicy) === -1) {
+      var goodVals = '\'' + SUPPORTED_TURNPOLICY_VALUES.join('\', \'') + '\'';
+
+      throw new Error('Bad turnpolicy value. Allowed values are: ' + goodVals);
+    }
+
+    if (params && params.blacklevel != null) {
+      if (typeof params.blacklevel !== 'number' || !utils.between(params.blacklevel, 0, 255)) {
+        throw new Error('Bad blacklevel value. Expected to be an integer in range 0..255');
+      }
+    }
+
+    if (params && params.optcurve != null && typeof params.optcurve !== 'boolean') {
+      throw new Error('\'optcurve\' must be Boolean');
+    }
+  },
+
+	/**
+   * Reads given image. Uses Jimp under the hood, so target can be whatever Jimp can take
+   *
+   * @param {*} target
+   * @param {Function} callback
+   */
+  loadImage: function(target, callback) {
     var self = this;
     var blackLevel = self._params.blacklevel;
 
@@ -961,10 +972,10 @@ Potrace2.prototype = {
     }
 
     Jimp.read(target, function(err, img){
-      if (err) return cb(err);
+      if (err) return callback(err);
 
       if (self._currentTarget !== target) {
-        return cb(new Error('loadImage method was used with another source since last time'));
+        return callback(new Error('loadImage method was used with another source since last time'));
       }
 
       var bitmap = new Bitmap(img.bitmap.width, img.bitmap.height);
@@ -978,11 +989,21 @@ Potrace2.prototype = {
       self._bitmap = bitmap;
       self._imageLoaded = true;
 
-      cb(null);
+      callback(null);
     });
   },
 
+	/**
+   * Processing loaded image
+   *
+   * @param {Function} [callback] - optional callback which is called when image is processed. However, this method is synchronous, so callback is unnecessary
+   * @returns {*}
+   */
   process: function(callback) {
+    if (!this._imageLoaded) {
+      throw new Error('Image should be loaded first');
+    }
+
     if (this._processed) {
       return callback();
     }
@@ -994,8 +1015,21 @@ Potrace2.prototype = {
     callback();
 	},
 
+  /**
+   * Sets algorithm parameters
+   *
+   * @param {Object}  newParams
+   * @param {*}       [newParams.turnpolicy]   - how to resolve ambiguities in path decomposition (default Potrace.TURNPOLICY_MINORITY)
+   * @param {Number}  [newParams.turdsize]     - suppress speckles of up to this size (default 2)
+   * @param {Number}  [newParams.alphamax]     - corner threshold parameter (default 1)
+   * @param {Boolean} [newParams.optcurve]     - curve optimization (default true)
+   * @param {Number}  [newParams.opttolerance] - curve optimization tolerance (default 0.2)
+   * @param {Number}  [newParams.blacklevel]   - treshold below which color is considered black (0..255, default 128)
+   */
 	setParameter: function(newParams) {
     var key;
+
+    this._validateParameters(newParams);
 
 		for (key in this._params) {
 			if (this._params.hasOwnProperty(key) && newParams.hasOwnProperty(key)) {
@@ -1005,15 +1039,20 @@ Potrace2.prototype = {
 		}
 	},
 
-	/**
-	 * Generates SVG
-	 *
-	 * @param scale
-	 * @param useCurves
+  /**
+   * Generates SVG image
+   *
+   * @param {Number} [scale]
+   * @param {Boolean} [useCurves]
+   * @returns {String}
 	 */
 	getSVG: function(scale, useCurves) {
 		scale = scale || 1;
 		useCurves = useCurves === true;
+
+    if (!this._imageLoaded) {
+      throw new Error('Image should be loaded first');
+    }
 
 		if (!this._processed) {
 			throw new Error('Image needs to be processed first.');
@@ -1038,4 +1077,4 @@ Potrace2.prototype = {
 	}
 };
 
-module.exports = Potrace2;
+module.exports = Potrace;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var Potrace = require('./Potrace');
+
+module.exports = new Potrace(); // exporting instance for backwards compatibility
+module.exports.Potrace = Potrace; // exporting constructor

--- a/lib/types/Bitmap.js
+++ b/lib/types/Bitmap.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var Point = require('./Point');
+
+function Bitmap(w, h) {
+  this.w = w;
+  this.h = h;
+  this.size = w * h;
+  this.arraybuffer = new ArrayBuffer(this.size);
+  this.data = new Int8Array(this.arraybuffer);
+}
+
+Bitmap.prototype = {
+  at: function(x, y) {    
+    return (x >= 0 && x < this.w && y >= 0 && y < this.h) &&
+      this.data[this.w * y + x] === 1;
+  },
+
+  /**
+   * 
+   * @param i
+   * @returns {Point}
+   */
+  index: function(i) {
+    var point = new Point();
+
+    point.y = Math.floor(i / this.w);
+    point.x = i - point.y * this.w;
+
+    return point;
+  },
+
+  flip: function(x, y) {
+    this.data[this.w * y + x] = this.at(x, y) ? 0 : 1;
+  },
+
+  copy: function() {
+    var bm = new Bitmap(this.w, this.h),
+        i;
+
+    for (i = 0; i < this.size; i++) {
+      bm.data[i] = this.data[i];
+    }
+
+    return bm;
+  }
+};
+
+module.exports = Bitmap;

--- a/lib/types/Bitmap.js
+++ b/lib/types/Bitmap.js
@@ -1,45 +1,92 @@
 'use strict';
 
 var Point = require('./Point');
+var utils = require('../utils');
 
+/**
+ * Represents a bitmap where each pixel can be a number in range of 0..255
+ * Used internally to store luminance data.
+ *
+ * @param {Number} w
+ * @param {Number} h
+ * @constructor
+ */
 function Bitmap(w, h) {
-  this.w = w;
-  this.h = h;
+  this.width = w;
+  this.height = h;
   this.size = w * h;
   this.arraybuffer = new ArrayBuffer(this.size);
-  this.data = new Int8Array(this.arraybuffer);
+  this.data = new Uint8Array(this.arraybuffer);
 }
 
 Bitmap.prototype = {
-  at: function(x, y) {    
-    return (x >= 0 && x < this.w && y >= 0 && y < this.h) &&
-      this.data[this.w * y + x] === 1;
+  /**
+   * Returns pixel value
+   *
+   * @param {Number|Point} x - index, point or x
+   * @param {Number} [y]
+   */
+  getValueAt: function(x, y) {
+    var index = (typeof x === 'number' && typeof y !== 'number') ? x : this.pointToIndex(x, y);
+    return this.data[index];
   },
 
   /**
-   * 
-   * @param i
+   * Converts {@link Point} to index value
+   *
+   * @param {Number} index
    * @returns {Point}
    */
-  index: function(i) {
+  indexToPoint: function(index) {
     var point = new Point();
 
-    point.y = Math.floor(i / this.w);
-    point.x = i - point.y * this.w;
+	  if (utils.between(index, 0, this.size)) {
+      point.y = Math.floor(index / this.width);
+      point.x = index - point.y * this.width;
+    } else {
+      point.x = -1;
+      point.y = -1;
+    }
 
     return point;
   },
 
-  flip: function(x, y) {
-    this.data[this.w * y + x] = this.at(x, y) ? 0 : 1;
+  /**
+   * Calculates index for point or coordinate pair
+   *
+   * @param {Number|Point} pointOrX
+   * @param {Number} [y]
+   * @returns {Number}
+   */
+  pointToIndex: function(pointOrX, y) {
+    var _x = pointOrX,
+        _y = y;
+
+    if (pointOrX instanceof Point) {
+      _x = pointOrX.x;
+      _y = pointOrX.y;
+    }
+
+    if (!utils.between(_x, 0, this.width) || !utils.between(_y, 0, this.height)) {
+      return -1;
+    }
+
+    return this.width * _y + _x;
   },
 
-  copy: function() {
-    var bm = new Bitmap(this.w, this.h),
+  /**
+   * Makes a copy of current bitmap
+   *
+   * @param {Function} [iterator] optional callback, used for processing pixel value. Accepted arguments: value, index
+   * @returns {Bitmap}
+   */
+  copy: function(iterator) {
+    var bm = new Bitmap(this.width, this.height),
+        iteratorPresent = typeof iterator === 'function',
         i;
 
     for (i = 0; i < this.size; i++) {
-      bm.data[i] = this.data[i];
+      bm.data[i] = iteratorPresent ? iterator(this.data[i], i) : this.data[i];
     }
 
     return bm;

--- a/lib/types/Curve.js
+++ b/lib/types/Curve.js
@@ -1,0 +1,14 @@
+'use strict';
+
+function Curve(n) {
+  this.n = n;
+  this.tag = new Array(n);
+  this.c = new Array(n * 3);
+  this.alphaCurve = 0;
+  this.vertex = new Array(n);
+  this.alpha = new Array(n);
+  this.alpha0 = new Array(n);
+  this.beta = new Array(n);
+}
+
+module.exports = Curve;

--- a/lib/types/Opti.js
+++ b/lib/types/Opti.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var Point = require('./Point');
+
+function Opti() {
+  this.pen = 0;
+  this.c = [new Point(), new Point()];
+  this.t = 0;
+  this.s = 0;
+  this.alpha = 0;
+}
+
+module.exports = Opti;

--- a/lib/types/Path.js
+++ b/lib/types/Path.js
@@ -1,0 +1,14 @@
+'use strict';
+
+function Path() {
+  this.area = 0;
+  this.len = 0;
+  this.curve = {};
+  this.pt = [];
+  this.minX = 100000;
+  this.minY = 100000;
+  this.maxX = -1;
+  this.maxY = -1;
+}
+
+module.exports = Path;

--- a/lib/types/Point.js
+++ b/lib/types/Point.js
@@ -1,14 +1,14 @@
 'use strict';
 
 function Point(x, y) {
-	this.x = x || 0;
-	this.y = y || 0;
+  this.x = x || 0;
+  this.y = y || 0;
 }
 
 Point.prototype = {
-	copy: function() {
-		return new Point(this.x, this.y);
-	}
+  copy: function() {
+    return new Point(this.x, this.y);
+  }
 };
 
 module.exports = Point;

--- a/lib/types/Point.js
+++ b/lib/types/Point.js
@@ -1,0 +1,14 @@
+'use strict';
+
+function Point(x, y) {
+	this.x = x || 0;
+	this.y = y || 0;
+}
+
+Point.prototype = {
+	copy: function() {
+		return new Point(this.x, this.y);
+	}
+};
+
+module.exports = Point;

--- a/lib/types/Quad.js
+++ b/lib/types/Quad.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function Quad() {
+  this.data = [0,0,0,0,0,0,0,0,0];
+}
+
+Quad.prototype.at = function(x, y) {
+  return this.data[x * 3 + y];
+};
+
+module.exports = Quad;

--- a/lib/types/Sum.js
+++ b/lib/types/Sum.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function Sum(x, y, xy, x2, y2) {
+  this.x = x;
+  this.y = y;
+  this.xy = xy;
+  this.x2 = x2;
+  this.y2 = y2;
+}
+
+module.exports = Sum;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -110,7 +110,7 @@ function ddist(p, q) {
 }
 
 module.exports = {
-	luminance: function (r, g, b) {
+  luminance: function (r, g, b) {
     return Math.round(0.2126 * r + 0.7153 * g + 0.0721 * b);
   },
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,6 @@
 
 var Point = require('./types/Point');
 
-
 function mod(a, n) {
   return a >= n ? a % n : a>=0 ? a : n-1-(-1-a) % n;
 }
@@ -115,7 +114,11 @@ module.exports = {
     return Math.round(0.2126 * r + 0.7153 * g + 0.0721 * b);
   },
 
-	/**
+  between: function(val, min, max) {
+    return val >= min && val <= max;
+  },
+
+  /**
    * Generates path instructions for given curve
    *
    * @param {Curve} curve
@@ -191,7 +194,6 @@ module.exports = {
       return -1.0;
     }
   },
-
 
   mod: mod,
   xprod: xprod,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,209 @@
+'use strict';
+
+var Point = require('./types/Point');
+
+
+function mod(a, n) {
+  return a >= n ? a % n : a>=0 ? a : n-1-(-1-a) % n;
+}
+
+function xprod(p1, p2) {
+  return p1.x * p2.y - p1.y * p2.x;
+}
+
+function cyclic(a, b, c) {
+  if (a <= c) {
+    return (a <= b && b < c);
+  } else {
+    return (a <= b || b < c);
+  }
+}
+
+function sign(i) {
+  return i > 0 ? 1 : i < 0 ? -1 : 0;
+}
+
+function quadform(Q, w) {
+  var v = new Array(3), i, j, sum;
+
+  v[0] = w.x;
+  v[1] = w.y;
+  v[2] = 1;
+  sum = 0.0;
+
+  for (i=0; i<3; i++) {
+    for (j=0; j<3; j++) {
+      sum += v[i] * Q.at(i, j) * v[j];
+    }
+  }
+  return sum;
+}
+
+function interval(lambda, a, b) {
+  var res = new Point();
+
+  res.x = a.x + lambda * (b.x - a.x);
+  res.y = a.y + lambda * (b.y - a.y);
+  return res;
+}
+
+function dorth_infty(p0, p2) {
+  var r = new Point();
+
+  r.y = sign(p2.x - p0.x);
+  r.x = -sign(p2.y - p0.y);
+
+  return r;
+}
+
+function ddenom(p0, p2) {
+  var r = dorth_infty(p0, p2);
+
+  return r.y * (p2.x - p0.x) - r.x * (p2.y - p0.y);
+}
+
+function dpara(p0, p1, p2) {
+  var x1, y1, x2, y2;
+
+  x1 = p1.x - p0.x;
+  y1 = p1.y - p0.y;
+  x2 = p2.x - p0.x;
+  y2 = p2.y - p0.y;
+
+  return x1 * y2 - x2 * y1;
+}
+
+function cprod(p0, p1, p2, p3) {
+  var x1, y1, x2, y2;
+
+  x1 = p1.x - p0.x;
+  y1 = p1.y - p0.y;
+  x2 = p3.x - p2.x;
+  y2 = p3.y - p2.y;
+
+  return x1 * y2 - x2 * y1;
+}
+
+function iprod(p0, p1, p2) {
+  var x1, y1, x2, y2;
+
+  x1 = p1.x - p0.x;
+  y1 = p1.y - p0.y;
+  x2 = p2.x - p0.x;
+  y2 = p2.y - p0.y;
+
+  return x1*x2 + y1*y2;
+}
+
+function iprod1(p0, p1, p2, p3) {
+  var x1, y1, x2, y2;
+
+  x1 = p1.x - p0.x;
+  y1 = p1.y - p0.y;
+  x2 = p3.x - p2.x;
+  y2 = p3.y - p2.y;
+
+  return x1 * x2 + y1 * y2;
+}
+
+function ddist(p, q) {
+  return Math.sqrt((p.x - q.x) * (p.x - q.x) + (p.y - q.y) * (p.y - q.y));
+}
+
+module.exports = {
+	luminance: function (r, g, b) {
+    return Math.round(0.2126 * r + 0.7153 * g + 0.0721 * b);
+  },
+
+	/**
+   * Generates path instructions for given curve
+   *
+   * @param {Curve} curve
+   * @param {Number} [scale]
+   * @returns {string}
+   */
+  renderCurve: function(curve, scale) {
+    scale = scale || 1;
+
+    var startingPoint = curve.c[(curve.n - 1) * 3 + 2];
+
+    var path = 'M '
+      + (startingPoint.x * scale).toFixed(3) + ' '
+      + (startingPoint.y * scale).toFixed(3) + ' ';
+
+    curve.tag.forEach(function(tag, i) {
+      var i3 = i * 3;
+      var p0 = curve.c[i3];
+      var p1 = curve.c[i3 + 1];
+      var p2 = curve.c[i3 + 2];
+
+      if (tag === "CURVE") {
+        path += 'C ';
+        path += (p0.x * scale).toFixed(3) + ' ' + (p0.y * scale).toFixed(3) + ',';
+        path += (p1.x * scale).toFixed(3) + ' ' + (p1.y * scale).toFixed(3) + ',';
+        path += (p2.x * scale).toFixed(3) + ' ' + (p2.y * scale).toFixed(3) + ' ';
+      } else if (tag === "CORNER") {
+        path += 'L ';
+        path += (p1.x * scale).toFixed(3) + ' ' + (p1.y * scale).toFixed(3) + ' ';
+        path += (p2.x * scale).toFixed(3) + ' ' + (p2.y * scale).toFixed(3) + ' ';
+      }
+    });
+
+    return path;
+  },
+  
+  bezier: function bezier(t, p0, p1, p2, p3) {
+    var s = 1 - t, res = new Point();
+
+    res.x = s*s*s*p0.x + 3*(s*s*t)*p1.x + 3*(t*t*s)*p2.x + t*t*t*p3.x;
+    res.y = s*s*s*p0.y + 3*(s*s*t)*p1.y + 3*(t*t*s)*p2.y + t*t*t*p3.y;
+
+    return res;
+  },
+
+  tangent: function tangent(p0, p1, p2, p3, q0, q1) {
+    var A, B, C, a, b, c, d, s, r1, r2;
+
+    A = cprod(p0, p1, q0, q1);
+    B = cprod(p1, p2, q0, q1);
+    C = cprod(p2, p3, q0, q1);
+
+    a = A - 2 * B + C;
+    b = -2 * A + 2 * B;
+    c = A;
+
+    d = b * b - 4 * a * c;
+
+    if (a===0 || d<0) {
+      return -1.0;
+    }
+
+    s = Math.sqrt(d);
+
+    r1 = (-b + s) / (2 * a);
+    r2 = (-b - s) / (2 * a);
+
+    if (r1 >= 0 && r1 <= 1) {
+      return r1;
+    } else if (r2 >= 0 && r2 <= 1) {
+      return r2;
+    } else {
+      return -1.0;
+    }
+  },
+
+
+  mod: mod,
+  xprod: xprod,
+  cyclic: cyclic,
+  sign: sign,
+  quadform: quadform,
+  interval: interval,
+  dorth_infty: dorth_infty,
+  ddenom: ddenom,
+  dpara: dpara,
+  cprod: cprod,
+  iprod: iprod,
+  iprod1: iprod1,
+  ddist: ddist
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "potrace",
   "version": "1.0.0",
   "description": "Potrace in Javascript, for NodeJS",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
     "test": "cd test && node test"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var potrace = require('../index'),
+var potrace = require('../lib/index'),
     fs = require('fs');
 
 potrace.loadImage('./yao.jpg', function(err) {


### PR DESCRIPTION
What's changed:

- Code was refactored. Types moved into separate CommonJS Modules, main algorithm now converted into OOP class as well. Public API is backwards compatible
- `loadImage` method does not perform comparison of pixel's liminance to a treshold anymore. 
Instead luminance values are recorded to `Bitmap` as is (which `data` property type was changed from `Int8Array` to `Uint8Array`). 

  Comparison to treshold (`blacklevel` setting) now performed later in `process` method, which allows us to re-process image with different parameters, without having to reload the raster image
- In case if `loadImage` method (on a single Potrace instance) was called before previous image was loaded - all previous calls will receive an error.

More changes is on the way