### PR TITLE
Upgrade Jimp to address minimist security vuln.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,283 +4,362 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@jimp/bmp": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.6.8.tgz",
-      "integrity": "sha512-uxVgSkI62uAzk5ZazYHEHBehow590WAkLKmDXLzkr/XP/Hv2Fx1T4DKwJ/15IY5ktq5VAhAUWGXTyd8KWFsx7w==",
+    "@babel/runtime": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@jimp/bmp": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.9.8.tgz",
+      "integrity": "sha512-CZYQPEC3iUBMuaGWrtIG+GKNl93q/PkdudrCKJR/B96dfNngsmoosEm3LuFgJHEcJIfvnJkNqKw74l+zEiqCbg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
         "bmp-js": "^0.1.0",
-        "core-js": "^2.5.7"
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/core": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.6.8.tgz",
-      "integrity": "sha512-JOFqBBcSNiDiMZJFr6OJqC6viXj5NVBQISua0eacoYvo4YJtTajOIxC4MqWyUmGrDpRMZBR8QhSsIOwsFrdROA==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.9.8.tgz",
+      "integrity": "sha512-N4GCjcXb0QwR5GBABDK2xQ3cKyaF7LlCYeJEG9mV7G/ynBoRqJe4JA6YKU9Ww9imGkci/4A594nQo8tUIqdcBw==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
         "any-base": "^1.1.0",
         "buffer": "^5.2.0",
-        "core-js": "^2.5.7",
+        "core-js": "^3.4.1",
         "exif-parser": "^0.1.12",
         "file-type": "^9.0.0",
         "load-bmfont": "^1.3.1",
-        "mkdirp": "0.5.1",
+        "mkdirp": "^0.5.1",
         "phin": "^2.9.1",
         "pixelmatch": "^4.0.2",
         "tinycolor2": "^1.4.1"
       }
     },
     "@jimp/custom": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.6.8.tgz",
-      "integrity": "sha512-FrYlzZRVXP2vuVwd7Nc2dlK+iZk4g6IaT1Ib8Z6vU5Kkwlt83FJIPJ2UUFABf3bF5big0wkk8ZUihWxE4Nzdng==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.9.8.tgz",
+      "integrity": "sha512-1UpJjI7fhX02BWLJ/KEqPwkHH60eNkCNeD6hEd+IZdTwLXfZCfFiM5BVlpgiZYZJSsVoRiAL4ne2Q5mCiKPKyw==",
       "requires": {
-        "@jimp/core": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/core": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/gif": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.6.8.tgz",
-      "integrity": "sha512-yyOlujjQcgz9zkjM5ihZDEppn9d1brJ7jQHP5rAKmqep0G7FU1D0AKcV+Ql18RhuI/CgWs10wAVcrQpmLnu4Yw==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.9.8.tgz",
+      "integrity": "sha512-LEbfpcO1sBJIQCJHchZjNlyNxzPjZQQ4X32klpQHZJG58n9FvL7Uuh1rpkrJRbqv3cU3P0ENNtTrsBDxsYwcfA==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7",
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1",
         "omggif": "^1.0.9"
       }
     },
     "@jimp/jpeg": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.6.8.tgz",
-      "integrity": "sha512-rGtXbYpFXAn471qLpTGvhbBMNHJo5KiufN+vC5AWyufntmkt5f0Ox2Cx4ijuBMDtirZchxbMLtrfGjznS4L/ew==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.9.8.tgz",
+      "integrity": "sha512-5u29SUzbZ32ZMmOaz3gO0hXatwSCnsvEAXRCKZoPPgbsPoyFAiZKVxjfLzjkeQF6awkvJ8hZni5chM15SNMg+g==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7",
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1",
         "jpeg-js": "^0.3.4"
       }
     },
     "@jimp/plugin-blit": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.6.8.tgz",
-      "integrity": "sha512-7Tl6YpKTSpvwQbnGNhsfX2zyl3jRVVopd276Y2hF2zpDz9Bycow7NdfNU/4Nx1jaf96X6uWOtSVINcQ7rGd47w==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.9.8.tgz",
+      "integrity": "sha512-6xTDomxJybhBcby1IUVaPydZFhxf+V0DRgfDlVK81kR9kSCoshJpzWqDuWrMqjNEPspPE7jRQwHMs0FdU7mVwQ==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-blur": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.6.8.tgz",
-      "integrity": "sha512-NpZCMKxXHLDQsX9zPlWtpMA660DQStY6/z8ZetyxCDbqrLe9YCXpeR4MNhdJdABIiwTm1W5FyFF4kp81PHJx3Q==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.9.8.tgz",
+      "integrity": "sha512-dqbxuNFBRbmt35iIRacdgma7nlXklmPThsKcGWNTDmqb/hniK5IC+0xSPzBV4qMI2fLGP39LWHqqDZ0xDz14dA==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
+      }
+    },
+    "@jimp/plugin-circle": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.9.8.tgz",
+      "integrity": "sha512-+UStXUPCzPqzTixLC8eVqcFcEa6TS+BEM/6/hyM11TDb9sbiMGeUtgpwZP/euR5H5gfpAQDA1Ppzqhh5fuMDlw==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-color": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.6.8.tgz",
-      "integrity": "sha512-jjFyU0zNmGOH2rjzHuOMU4kaia0oo82s/7UYfn5h7OUkmUZTd6Do3ZSK1PiXA7KR+s4B76/Omm6Doh/0SGb7BQ==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.9.8.tgz",
+      "integrity": "sha512-SDHxOQsJHpt75hk6+sSlCPc2B3UJlXosFW+iLZ11xX1Qr0IdDtbfYlIoPmjKQFIDUNzqLSue/z7sKQ1OMZr/QA==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7",
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1",
         "tinycolor2": "^1.4.1"
       }
     },
     "@jimp/plugin-contain": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.6.8.tgz",
-      "integrity": "sha512-p/P2wCXhAzbmEgXvGsvmxLmbz45feF6VpR4m9suPSOr8PC/i/XvTklTqYEUidYYAft4vHgsYJdS74HKSMnH8lw==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.9.8.tgz",
+      "integrity": "sha512-oK52CPt7efozuLYCML7qOmpFeDt3zpU8qq8UZlnjsDs15reU6L8EiUbwYpJvzoEnEOh1ZqamB8F/gymViEO5og==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-cover": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.6.8.tgz",
-      "integrity": "sha512-2PvWgk+PJfRsfWDI1G8Fpjrsu0ZlpNyZxO2+fqWlVo6y/y2gP4v08FqvbkcqSjNlOu2IDWIFXpgyU0sTINWZLg==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.9.8.tgz",
+      "integrity": "sha512-nnamtHzMrNd5j5HRSPd1VzpZ8v9YYtUJPtvCdHOOiIjqG72jxJ2kTBlsS3oG5XS64h/2MJwpl/fmmMs1Tj1CmQ==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-crop": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.6.8.tgz",
-      "integrity": "sha512-CbrcpWE2xxPK1n/JoTXzhRUhP4mO07mTWaSavenCg664oQl/9XCtL+A0FekuNHzIvn4myEqvkiTwN7FsbunS/Q==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.9.8.tgz",
+      "integrity": "sha512-Nv/6AIp4aJmbSIH2uiIqm+kSoShKM8eaX2fyrUTj811kio0hwD3f/vIxrWebvAqwDZjAFIAmMufFoFCVg6caoQ==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-displace": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.6.8.tgz",
-      "integrity": "sha512-RmV2bPxoPE6mrPxtYSPtHxm2cGwBQr5a2p+9gH6SPy+eUMrbGjbvjwKNfXWUYD0leML+Pt5XOmAS9pIROmuruQ==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.9.8.tgz",
+      "integrity": "sha512-0OgPjkOVa2xdbqI8P6gBKX/UK36RbaYVrFyXL8Jy9oNF69+LYWyTskuCu9YbGxzlCVjY/JFqQOvrKDbxgMYAKA==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-dither": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.6.8.tgz",
-      "integrity": "sha512-x6V/qjxe+xypjpQm7GbiMNqci1EW5UizrcebOhHr8AHijOEqHd2hjXh5f6QIGfrkTFelc4/jzq1UyCsYntqz9Q==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.9.8.tgz",
+      "integrity": "sha512-jGM/4ByniZJnmV2fv8hKwyyydXZe/YzvgBcnB8XxzCq8kVR3Imcn+qnd2PEPZzIPKOTH4Cig/zo9Vk9Bs+m5FQ==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
+      }
+    },
+    "@jimp/plugin-fisheye": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.9.8.tgz",
+      "integrity": "sha512-VnsalrD05f4pxG1msjnkwIFi5QveOqRm4y7VkoZKNX+iqs4TvRnH5+HpBnfdMzX/RXBi+Lf/kpTtuZgbOu/QWw==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-flip": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.6.8.tgz",
-      "integrity": "sha512-4il6Da6G39s9MyWBEee4jztEOUGJ40E6OlPjkMrdpDNvge6hYEAB31BczTYBP/CEY74j4LDSoY5LbcU4kv06yA==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.9.8.tgz",
+      "integrity": "sha512-XbiZ4OfHD6woc0f6Sk7XxB6a7IyMjTRQ4pNU7APjaNxsl3L6qZC8qfCQphWVe3DHx7f3y7jEiPMvNnqRDP1xgA==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-gaussian": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.6.8.tgz",
-      "integrity": "sha512-pVOblmjv7stZjsqloi4YzHVwAPXKGdNaHPhp4KP4vj41qtc6Hxd9z/+VWGYRTunMFac84gUToe0UKIXd6GhoKw==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.9.8.tgz",
+      "integrity": "sha512-ZBl5RA6+4XAD+mtqLfiG7u+qd8W5yqq3RBNca8eFqUSVo1v+eB2tzeLel0CWfVC/z6cw93Awm/nVnm6/CL2Oew==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-invert": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.6.8.tgz",
-      "integrity": "sha512-11zuLiXDHr6tFv4U8aieXqNXQEKbDbSBG/h+X62gGTNFpyn8EVPpncHhOqrAFtZUaPibBqMFlNJ15SzwC7ExsQ==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.9.8.tgz",
+      "integrity": "sha512-ESploqCoF6qUv5IWhVLaO5fEcrYZEsAWPFflh6ROiD2mmFKQxfeK+vHnk3IDLHtUwWTkAZQNbk89BVq7xvaNpQ==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-mask": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.6.8.tgz",
-      "integrity": "sha512-hZJ0OiKGJyv7hDSATwJDkunB1Ie80xJnONMgpUuUseteK45YeYNBOiZVUe8vum8QI1UwavgBzcvQ9u4fcgXc9g==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.9.8.tgz",
+      "integrity": "sha512-zSvEisTV4iGsBReitEdnQuGJq9/1xB5mPATadYZmIlp8r5HpD72HQb0WdEtb51/pu9Odt8KAxUf0ASg/PRVUiQ==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-normalize": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.6.8.tgz",
-      "integrity": "sha512-Q4oYhU+sSyTJI7pMZlg9/mYh68ujLfOxXzQGEXuw0sHGoGQs3B0Jw7jmzGa6pIS06Hup5hD2Zuh1ppvMdjJBfQ==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.9.8.tgz",
+      "integrity": "sha512-dPFBfwTa67K1tRw1leCidQT25R3ozrTUUOpO4jcGFHqXvBTWaR8sML1qxdfOBWs164mE5YpfdTvu6MM/junvCg==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-print": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.6.8.tgz",
-      "integrity": "sha512-2aokejGn4Drv1FesnZGqh5KEq0FQtR0drlmtyZrBH+r9cx7hh0Qgf4D1BOTDEgXkfSSngjGRjKKRW/fwOrVXYw==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.9.8.tgz",
+      "integrity": "sha512-nLLPv1/faehRsOjecXXUb6kzhRcZzImO55XuFZ0c90ZyoiHm4UFREwO5sKxHGvpLXS6RnkhvSav4+IWD2qGbEQ==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7",
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1",
         "load-bmfont": "^1.4.0"
       }
     },
     "@jimp/plugin-resize": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.6.8.tgz",
-      "integrity": "sha512-27nPh8L1YWsxtfmV/+Ub5dOTpXyC0HMF2cu52RQSCYxr+Lm1+23dJF70AF1poUbUe+FWXphwuUxQzjBJza9UoA==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.9.8.tgz",
+      "integrity": "sha512-L80NZ+HKsiKFyeDc6AfneC4+5XACrdL2vnyAVfAAsb3pmamgT/jDInWvvGhyI0Y76vx2w6XikplzEznW/QQvWg==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-rotate": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.6.8.tgz",
-      "integrity": "sha512-GbjETvL05BDoLdszNUV4Y0yLkHf177MnqGqilA113LIvx9aD0FtUopGXYfRGVvmtTOTouoaGJUc+K6qngvKxww==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.9.8.tgz",
+      "integrity": "sha512-bpqzQheISYnBXKyU1lIj46uR7mRs0UhgEREWK70HnvFJSlRshdcoNMIrKamyrJeFdJrkYPSfR/a6D0d5zsWf1Q==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-scale": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.6.8.tgz",
-      "integrity": "sha512-GzIYWR/oCUK2jAwku23zt19V1ssaEU4pL0x2XsLNKuuJEU6DvEytJyTMXCE7OLG/MpDBQcQclJKHgiyQm5gIOQ==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.9.8.tgz",
+      "integrity": "sha512-QU3ZS4Lre8nN66U9dKCOC4FNfaOh/QJFYUmQPKpPS924oYbtnm4OlmsdfpK2hVMSVVyVOis8M+xpA1rDBnIp7w==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
+      }
+    },
+    "@jimp/plugin-shadow": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.9.8.tgz",
+      "integrity": "sha512-t/pE+QS3r1ZUxGIQNmwWDI3c5+/hLU+gxXD+C3EEC47/qk3gTBHpj/xDdGQBoObdT/HRjR048vC2BgBfzjj2hg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
+      }
+    },
+    "@jimp/plugin-threshold": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.9.8.tgz",
+      "integrity": "sha512-WWmC3lnIwOTPvkKu55w4DUY8Ehlzf3nU98bY0QtIzkqxkAOZU5m+lvgC/JxO5FyGiA57j9FLMIf0LsWkjARj7g==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1"
       }
     },
     "@jimp/plugins": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.6.8.tgz",
-      "integrity": "sha512-fMcTI72Vn/Lz6JftezTURmyP5ml/xGMe0Ljx2KRJ85IWyP33vDmGIUuutFiBEbh2+y7lRT+aTSmjs0QGa/xTmQ==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.9.8.tgz",
+      "integrity": "sha512-tD+cxS9SuEZaQ1hhAkNKw9TkUAqfoBAhdWPBrEZDr/GvGPrvJR4pYmmpSYhc5IZmMbXfQayHTTGqjj8D18bToA==",
       "requires": {
-        "@jimp/plugin-blit": "^0.6.8",
-        "@jimp/plugin-blur": "^0.6.8",
-        "@jimp/plugin-color": "^0.6.8",
-        "@jimp/plugin-contain": "^0.6.8",
-        "@jimp/plugin-cover": "^0.6.8",
-        "@jimp/plugin-crop": "^0.6.8",
-        "@jimp/plugin-displace": "^0.6.8",
-        "@jimp/plugin-dither": "^0.6.8",
-        "@jimp/plugin-flip": "^0.6.8",
-        "@jimp/plugin-gaussian": "^0.6.8",
-        "@jimp/plugin-invert": "^0.6.8",
-        "@jimp/plugin-mask": "^0.6.8",
-        "@jimp/plugin-normalize": "^0.6.8",
-        "@jimp/plugin-print": "^0.6.8",
-        "@jimp/plugin-resize": "^0.6.8",
-        "@jimp/plugin-rotate": "^0.6.8",
-        "@jimp/plugin-scale": "^0.6.8",
-        "core-js": "^2.5.7",
+        "@babel/runtime": "^7.7.2",
+        "@jimp/plugin-blit": "^0.9.8",
+        "@jimp/plugin-blur": "^0.9.8",
+        "@jimp/plugin-circle": "^0.9.8",
+        "@jimp/plugin-color": "^0.9.8",
+        "@jimp/plugin-contain": "^0.9.8",
+        "@jimp/plugin-cover": "^0.9.8",
+        "@jimp/plugin-crop": "^0.9.8",
+        "@jimp/plugin-displace": "^0.9.8",
+        "@jimp/plugin-dither": "^0.9.8",
+        "@jimp/plugin-fisheye": "^0.9.8",
+        "@jimp/plugin-flip": "^0.9.8",
+        "@jimp/plugin-gaussian": "^0.9.8",
+        "@jimp/plugin-invert": "^0.9.8",
+        "@jimp/plugin-mask": "^0.9.8",
+        "@jimp/plugin-normalize": "^0.9.8",
+        "@jimp/plugin-print": "^0.9.8",
+        "@jimp/plugin-resize": "^0.9.8",
+        "@jimp/plugin-rotate": "^0.9.8",
+        "@jimp/plugin-scale": "^0.9.8",
+        "@jimp/plugin-shadow": "^0.9.8",
+        "@jimp/plugin-threshold": "^0.9.8",
+        "core-js": "^3.4.1",
         "timm": "^1.6.1"
       }
     },
     "@jimp/png": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.6.8.tgz",
-      "integrity": "sha512-JHHg/BZ7KDtHQrcG+a7fztw45rdf7okL/YwkN4qU5FH7Fcrp41nX5QnRviDtD9hN+GaNC7kvjvcqRAxW25qjew==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.9.8.tgz",
+      "integrity": "sha512-9CqR8d40zQCDhbnXHqcwkAMnvlV0vk9xSyE6LHjkYHS7x18Unsz5txQdsaEkEcXxCrOQSoWyITfLezlrWXRJAA==",
       "requires": {
-        "@jimp/utils": "^0.6.8",
-        "core-js": "^2.5.7",
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.9.8",
+        "core-js": "^3.4.1",
         "pngjs": "^3.3.3"
       }
     },
     "@jimp/tiff": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.6.8.tgz",
-      "integrity": "sha512-iWHbxd+0IKWdJyJ0HhoJCGYmtjPBOusz1z1HT/DnpePs/Lo3TO4d9ALXqYfUkyG74ZK5jULZ69KLtwuhuJz1bg==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.9.8.tgz",
+      "integrity": "sha512-eMxcpJivJqMByn2dZxUHLeh6qvVs5J/52kBF3TFa3C922OJ97D9l1C1h0WKUCBqFMWzMYapQQ4vwnLgpJ5tkow==",
       "requires": {
-        "core-js": "^2.5.7",
+        "@babel/runtime": "^7.7.2",
+        "core-js": "^3.4.1",
         "utif": "^2.0.1"
       }
     },
     "@jimp/types": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.6.8.tgz",
-      "integrity": "sha512-vCZ/Cp2osy69VP21XOBACfHI5HeR60Rfd4Jidj4W73UL+HrFWOtyQiJ7hlToyu1vI5mR/NsUQpzyQvz56ADm5A==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.9.8.tgz",
+      "integrity": "sha512-H5y/uqt0lqJ/ZN8pWqFG+pv8jPAppMKkTMByuC8YBIjWSsornwv44hjiWl93sbYhduLZY8ubz/CbX9jH2X6EwA==",
       "requires": {
-        "@jimp/bmp": "^0.6.8",
-        "@jimp/gif": "^0.6.8",
-        "@jimp/jpeg": "^0.6.8",
-        "@jimp/png": "^0.6.8",
-        "@jimp/tiff": "^0.6.8",
-        "core-js": "^2.5.7",
+        "@babel/runtime": "^7.7.2",
+        "@jimp/bmp": "^0.9.8",
+        "@jimp/gif": "^0.9.8",
+        "@jimp/jpeg": "^0.9.8",
+        "@jimp/png": "^0.9.8",
+        "@jimp/tiff": "^0.9.8",
+        "core-js": "^3.4.1",
         "timm": "^1.6.1"
       }
     },
     "@jimp/utils": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.6.8.tgz",
-      "integrity": "sha512-7RDfxQ2C/rarNG9iso5vmnKQbcvlQjBIlF/p7/uYj72WeZgVCB+5t1fFBKJSU4WhniHX4jUMijK+wYGE3Y3bGw==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.9.8.tgz",
+      "integrity": "sha512-UK0Fu0eevQlpRXq5ff4o/71HJlpX9wJMddJjMYg9vUqCCl8ZnumRAljfShHFhGyO+Vc9IzN6dd8Y5JZZTp1KOw==",
       "requires": {
-        "core-js": "^2.5.7"
+        "@babel/runtime": "^7.7.2",
+        "core-js": "^3.4.1"
       }
     },
     "@sinonjs/commons": {
@@ -495,9 +574,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
     },
     "debug": {
       "version": "3.2.6",
@@ -765,14 +844,15 @@
       "dev": true
     },
     "jimp": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.6.8.tgz",
-      "integrity": "sha512-F7emeG7Hp61IM8VFbNvWENLTuHe0ghizWPuP4JS9ujx2r5mCVYEd/zdaz6M2M42ZdN41blxPajLWl9FXo7Mr2Q==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.9.8.tgz",
+      "integrity": "sha512-DHN4apKMwLIvD/TKO9tFfPuankNuVK98vCwHm/Jv9z5cJnrd38xhi+4I7IAGmDU3jIDlrEVhzTkFH1Ymv5yTQQ==",
       "requires": {
-        "@jimp/custom": "^0.6.8",
-        "@jimp/plugins": "^0.6.8",
-        "@jimp/types": "^0.6.8",
-        "core-js": "^2.5.7",
+        "@babel/runtime": "^7.7.2",
+        "@jimp/custom": "^0.9.8",
+        "@jimp/plugins": "^0.9.8",
+        "@jimp/types": "^0.9.8",
+        "core-js": "^3.4.1",
         "regenerator-runtime": "^0.13.3"
       }
     },
@@ -866,16 +946,16 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+      "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/tooolbox/node-potrace#readme",
   "dependencies": {
-    "jimp": "^0.6.4"
+    "jimp": "^0.9.6"
   },
   "devDependencies": {
     "lodash": "^4.17.11",


### PR DESCRIPTION
Since the pull request for Jimp addressing `minimist` security vulnerability (https://www.npmjs.com/advisories/1179) was accepted, it would be good to upgrade to at least `0.9.6`:

https://github.com/oliver-moran/jimp/pull/857

Original fix in `mkdirp`: https://github.com/isaacs/node-mkdirp/issues/7#issuecomment-600231795

It seems like the last minor releases have not changed anything breaking...?

- https://github.com/oliver-moran/jimp/releases/tag/v0.7.0
- https://github.com/oliver-moran/jimp/releases/tag/v0.8.0
- https://github.com/oliver-moran/jimp/releases/tag/v0.9.0

If this is accepted and released as a minor or patch, this will also enable Gatsby projects to fix the security issues without breaking semver, since `gatsby-plugin-sharp` and `gatsby-transformer-sharp` depend on `potrace@^2.1.2`:

- https://github.com/gatsbyjs/gatsby/blob/2ff2ba395a86407e3ccfd1e010be7408a4817a82/packages/gatsby-plugin-sharp/package.json#L22
- https://github.com/gatsbyjs/gatsby/blob/2ff2ba395a86407e3ccfd1e010be7408a4817a82/packages/gatsby-transformer-sharp/package.json#L13