### PR TITLE
Fixes the jimp dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "potrace",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,23 +13,23 @@
       }
     },
     "@jimp/bmp": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.9.8.tgz",
-      "integrity": "sha512-CZYQPEC3iUBMuaGWrtIG+GKNl93q/PkdudrCKJR/B96dfNngsmoosEm3LuFgJHEcJIfvnJkNqKw74l+zEiqCbg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.10.2.tgz",
+      "integrity": "sha512-vsLwkfj6rcxtSxEdpQaxDagrgpOB0ErHTS/vVRQKDIhrzZkW1ddQa9W1hV8qssSY3K7lz1QNYFQdeRw/qoCiBA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "bmp-js": "^0.1.0",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/core": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.9.8.tgz",
-      "integrity": "sha512-N4GCjcXb0QwR5GBABDK2xQ3cKyaF7LlCYeJEG9mV7G/ynBoRqJe4JA6YKU9Ww9imGkci/4A594nQo8tUIqdcBw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.10.2.tgz",
+      "integrity": "sha512-oyJLzWYcT6u0joD2YJAAVqCc1Ng9wXGPdAijWy3xxQT/roALmWLGL5ev6fQ/gugPVAD+xKUQpM0OxJepRYUl0Q==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "any-base": "^1.1.0",
         "buffer": "^5.2.0",
         "core-js": "^3.4.1",
@@ -43,295 +43,295 @@
       }
     },
     "@jimp/custom": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.9.8.tgz",
-      "integrity": "sha512-1UpJjI7fhX02BWLJ/KEqPwkHH60eNkCNeD6hEd+IZdTwLXfZCfFiM5BVlpgiZYZJSsVoRiAL4ne2Q5mCiKPKyw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.10.2.tgz",
+      "integrity": "sha512-+ErCKYrIC0m6nDxRwIq0ETdltL4+C8RKrv3bGW/bI94QSfIXCdP6Vsz03VMae1J9+IPjfhn1LJ5rQ3zWkZEfdA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/core": "^0.9.8",
+        "@jimp/core": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/gif": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.9.8.tgz",
-      "integrity": "sha512-LEbfpcO1sBJIQCJHchZjNlyNxzPjZQQ4X32klpQHZJG58n9FvL7Uuh1rpkrJRbqv3cU3P0ENNtTrsBDxsYwcfA==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.10.2.tgz",
+      "integrity": "sha512-Evkwr7Vlt5zMqNccsUDetHpKtvhFz07yg8BRZl3kXzkeKeaK/PbuAV7yjXn1DxVVU+1uSS765MdbsMVe7J404A==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1",
         "omggif": "^1.0.9"
       }
     },
     "@jimp/jpeg": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.9.8.tgz",
-      "integrity": "sha512-5u29SUzbZ32ZMmOaz3gO0hXatwSCnsvEAXRCKZoPPgbsPoyFAiZKVxjfLzjkeQF6awkvJ8hZni5chM15SNMg+g==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.10.2.tgz",
+      "integrity": "sha512-+aQUGBZI6OueB0K6gqLCwehV5skZceVyZjjmPmuXaE7ZvdhFMP2QDh45vcT8LzlPGUcOwpIWxsGHrB6Q6RcFXQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1",
         "jpeg-js": "^0.3.4"
       }
     },
     "@jimp/plugin-blit": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.9.8.tgz",
-      "integrity": "sha512-6xTDomxJybhBcby1IUVaPydZFhxf+V0DRgfDlVK81kR9kSCoshJpzWqDuWrMqjNEPspPE7jRQwHMs0FdU7mVwQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.10.2.tgz",
+      "integrity": "sha512-PdqKZLkwnOOnrr+M4X4K/GrQ26qeCHut7AoFbKW+BsHooHvyadOWwVTBUBfK8GyDp/NApEC9SXbT0UNk8XqabA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-blur": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.9.8.tgz",
-      "integrity": "sha512-dqbxuNFBRbmt35iIRacdgma7nlXklmPThsKcGWNTDmqb/hniK5IC+0xSPzBV4qMI2fLGP39LWHqqDZ0xDz14dA==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.10.2.tgz",
+      "integrity": "sha512-9KeLyUY3s5N0cPZN4uMg0qIiSDvIPhXEnpYnXdN2V53dM25sKrBCMH578/W+n9hAHVpsbJHS+VFknO1JV47QVw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-circle": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.9.8.tgz",
-      "integrity": "sha512-+UStXUPCzPqzTixLC8eVqcFcEa6TS+BEM/6/hyM11TDb9sbiMGeUtgpwZP/euR5H5gfpAQDA1Ppzqhh5fuMDlw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.10.2.tgz",
+      "integrity": "sha512-wOJ3qKa916YZMEwA9qwIn8yROYonkscJ3bqaaSsyf5CadiY8VCijKxA3BVwr7PKjj89yf5RCS4mcy+CO8+nmkw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-color": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.9.8.tgz",
-      "integrity": "sha512-SDHxOQsJHpt75hk6+sSlCPc2B3UJlXosFW+iLZ11xX1Qr0IdDtbfYlIoPmjKQFIDUNzqLSue/z7sKQ1OMZr/QA==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.10.2.tgz",
+      "integrity": "sha512-c6cw41Hn3tLYQIRg3hxXrefKcOfW4jRN9b9DGH16mcZrRtw5jMzq3NfZ+RLQM47SyAE7N2BeUz0Ah3pmCArI0g==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1",
         "tinycolor2": "^1.4.1"
       }
     },
     "@jimp/plugin-contain": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.9.8.tgz",
-      "integrity": "sha512-oK52CPt7efozuLYCML7qOmpFeDt3zpU8qq8UZlnjsDs15reU6L8EiUbwYpJvzoEnEOh1ZqamB8F/gymViEO5og==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.10.2.tgz",
+      "integrity": "sha512-oDDe+XdpSwx2OQOSb6ar4O31+4d02Qz4R+1BeucuO7FzOrbDggnCWavSg6RevyOJPDKGkmv8Jj3V6S0jUwgVgw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-cover": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.9.8.tgz",
-      "integrity": "sha512-nnamtHzMrNd5j5HRSPd1VzpZ8v9YYtUJPtvCdHOOiIjqG72jxJ2kTBlsS3oG5XS64h/2MJwpl/fmmMs1Tj1CmQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.10.2.tgz",
+      "integrity": "sha512-cnEqx8kHqBvQA+axKA8qRshwAIIfyxAwjdeRB/LZ9bWroh8XvbifW5buBgITDG5KklDkBhivmDEtPY90r3mMFQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-crop": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.9.8.tgz",
-      "integrity": "sha512-Nv/6AIp4aJmbSIH2uiIqm+kSoShKM8eaX2fyrUTj811kio0hwD3f/vIxrWebvAqwDZjAFIAmMufFoFCVg6caoQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.10.2.tgz",
+      "integrity": "sha512-6uTb3LMP0kiMqYOAHyU/q/pkScw6aRWkTSxhjgcsewQS3zPHWTSGgP8u6CNAFnlDmVYVIz/jdKlFnnOdf0ZwrA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-displace": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.9.8.tgz",
-      "integrity": "sha512-0OgPjkOVa2xdbqI8P6gBKX/UK36RbaYVrFyXL8Jy9oNF69+LYWyTskuCu9YbGxzlCVjY/JFqQOvrKDbxgMYAKA==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.10.2.tgz",
+      "integrity": "sha512-AGQDlyeFJz+zszYUkIzi5QyLLPsJzRJNIplU0S0HBxmXf5tZEeiiEtmsaC4j9VoAVD9Jwwn39+cfwV88Ij7WGg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-dither": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.9.8.tgz",
-      "integrity": "sha512-jGM/4ByniZJnmV2fv8hKwyyydXZe/YzvgBcnB8XxzCq8kVR3Imcn+qnd2PEPZzIPKOTH4Cig/zo9Vk9Bs+m5FQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.10.2.tgz",
+      "integrity": "sha512-TEu7n44OS/+F1eWqKumsKYI+i2cPxzRTmxJhxrsUGyDD2aNi7tCIfKILXDqO6Ii0tYgSqwakG2+Eu0Jqg7J/VQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-fisheye": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.9.8.tgz",
-      "integrity": "sha512-VnsalrD05f4pxG1msjnkwIFi5QveOqRm4y7VkoZKNX+iqs4TvRnH5+HpBnfdMzX/RXBi+Lf/kpTtuZgbOu/QWw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.10.2.tgz",
+      "integrity": "sha512-kxtfkcnnXitqpTxGaZg/q6bzMBRWCFEWs7maMIgjFkGvXsMegQ90EdKF1Ku76/gCTIGxyfbped8QD/+iACgzFw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-flip": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.9.8.tgz",
-      "integrity": "sha512-XbiZ4OfHD6woc0f6Sk7XxB6a7IyMjTRQ4pNU7APjaNxsl3L6qZC8qfCQphWVe3DHx7f3y7jEiPMvNnqRDP1xgA==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.10.2.tgz",
+      "integrity": "sha512-JW/aAKPGYOEGrqldpUBFxHUZ21pwhtxeRiwXEyMu/8N23PVuNBAePKboPMxRvkSLvAOn122xKEyCQvF10v/TOQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-gaussian": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.9.8.tgz",
-      "integrity": "sha512-ZBl5RA6+4XAD+mtqLfiG7u+qd8W5yqq3RBNca8eFqUSVo1v+eB2tzeLel0CWfVC/z6cw93Awm/nVnm6/CL2Oew==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.10.2.tgz",
+      "integrity": "sha512-uP1up3fCIBzGexqs/+HMGBoZckEEcic09RNRj5Lq6EUVY8vFdKeBk3F+tAA+fstpA6yHhjPk1w7FZKX/tkECNw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-invert": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.9.8.tgz",
-      "integrity": "sha512-ESploqCoF6qUv5IWhVLaO5fEcrYZEsAWPFflh6ROiD2mmFKQxfeK+vHnk3IDLHtUwWTkAZQNbk89BVq7xvaNpQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.10.2.tgz",
+      "integrity": "sha512-zm1NB+AS0fTKW0gmFs1Tjgkj892gtnDicyxzmYeCLoQzPTr/1iPVf2EGidCS88+aw04sA5DOu0UX7637ib7TkA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-mask": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.9.8.tgz",
-      "integrity": "sha512-zSvEisTV4iGsBReitEdnQuGJq9/1xB5mPATadYZmIlp8r5HpD72HQb0WdEtb51/pu9Odt8KAxUf0ASg/PRVUiQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.10.2.tgz",
+      "integrity": "sha512-4pVBAU6d/7EhfYs8sYuBGB3JMIuvrdiXbt6ESNs4CyDSbiDT4z1/f2sjWvNyLYlJ7cQJ+we50qqvq8vvNnb5lA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-normalize": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.9.8.tgz",
-      "integrity": "sha512-dPFBfwTa67K1tRw1leCidQT25R3ozrTUUOpO4jcGFHqXvBTWaR8sML1qxdfOBWs164mE5YpfdTvu6MM/junvCg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.10.2.tgz",
+      "integrity": "sha512-B2HXf6uaH8EAyZA5KvVYJOfv4AZpferIuDhOQSqDLKAEBBfEViwHk/Rn+nCUzGsAzQ/yiVtKAil68YcybaI6oQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-print": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.9.8.tgz",
-      "integrity": "sha512-nLLPv1/faehRsOjecXXUb6kzhRcZzImO55XuFZ0c90ZyoiHm4UFREwO5sKxHGvpLXS6RnkhvSav4+IWD2qGbEQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.10.2.tgz",
+      "integrity": "sha512-YXKBG5yNOr/DX958Omk1GzTrprRJ3YXWhJ6tzCbboxqXK6pErLDxFsa1mlngDGb/a43oGs63Myj7CuGf98/vaw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1",
         "load-bmfont": "^1.4.0"
       }
     },
     "@jimp/plugin-resize": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.9.8.tgz",
-      "integrity": "sha512-L80NZ+HKsiKFyeDc6AfneC4+5XACrdL2vnyAVfAAsb3pmamgT/jDInWvvGhyI0Y76vx2w6XikplzEznW/QQvWg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.10.2.tgz",
+      "integrity": "sha512-F+pXSU5sbACqqArZfVeYYXrq7qMwZcMs97Z3V70qsLtvDSVyNFG5iYpJhFKJOj05O7a2G7FQ1Nq2h0UKJdlLJg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-rotate": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.9.8.tgz",
-      "integrity": "sha512-bpqzQheISYnBXKyU1lIj46uR7mRs0UhgEREWK70HnvFJSlRshdcoNMIrKamyrJeFdJrkYPSfR/a6D0d5zsWf1Q==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.10.2.tgz",
+      "integrity": "sha512-bQ0RQuXS768G9l1HemULJ7puuevU5N3TpE1QV5NdzbKwjHidFAAavp8XFXOhd2Mj/Xh/3iFlMMEB7NG/McYoOA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-scale": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.9.8.tgz",
-      "integrity": "sha512-QU3ZS4Lre8nN66U9dKCOC4FNfaOh/QJFYUmQPKpPS924oYbtnm4OlmsdfpK2hVMSVVyVOis8M+xpA1rDBnIp7w==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.10.2.tgz",
+      "integrity": "sha512-47GRG3joOGDBLHYyLR0tc3hEz/H8tgPcLZaNEAaIdyL+ckAWQIgnoytbqj7OEAFeMj5j+loNm+ahJVX7w/X/ug==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-shadow": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.9.8.tgz",
-      "integrity": "sha512-t/pE+QS3r1ZUxGIQNmwWDI3c5+/hLU+gxXD+C3EEC47/qk3gTBHpj/xDdGQBoObdT/HRjR048vC2BgBfzjj2hg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.10.2.tgz",
+      "integrity": "sha512-koksEMJZKjq8OiprLh+ffrRo/x/dXHCsfaKS4kf2EoFZEb6sZHeJgKLwozLky1DXBPiMryYSrNt8Cb6wzjd1zA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugin-threshold": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.9.8.tgz",
-      "integrity": "sha512-WWmC3lnIwOTPvkKu55w4DUY8Ehlzf3nU98bY0QtIzkqxkAOZU5m+lvgC/JxO5FyGiA57j9FLMIf0LsWkjARj7g==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.10.2.tgz",
+      "integrity": "sha512-RQzxB40KK50iUUNLF9M7G3dVKFmbe/T4EQVWMPxxX8NQPNbU0vjZzTW0vVYoTYno2vLxewQgV0Y3ydX/l08NLg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1"
       }
     },
     "@jimp/plugins": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.9.8.tgz",
-      "integrity": "sha512-tD+cxS9SuEZaQ1hhAkNKw9TkUAqfoBAhdWPBrEZDr/GvGPrvJR4pYmmpSYhc5IZmMbXfQayHTTGqjj8D18bToA==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.10.2.tgz",
+      "integrity": "sha512-z4Fhu97WZIussTzd1PJXUUuluushXlfCYzXifixf8fGAoVGZuMMJl6aqtuy4eUOgLyN8sXun0MzdWAahelqbfA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/plugin-blit": "^0.9.8",
-        "@jimp/plugin-blur": "^0.9.8",
-        "@jimp/plugin-circle": "^0.9.8",
-        "@jimp/plugin-color": "^0.9.8",
-        "@jimp/plugin-contain": "^0.9.8",
-        "@jimp/plugin-cover": "^0.9.8",
-        "@jimp/plugin-crop": "^0.9.8",
-        "@jimp/plugin-displace": "^0.9.8",
-        "@jimp/plugin-dither": "^0.9.8",
-        "@jimp/plugin-fisheye": "^0.9.8",
-        "@jimp/plugin-flip": "^0.9.8",
-        "@jimp/plugin-gaussian": "^0.9.8",
-        "@jimp/plugin-invert": "^0.9.8",
-        "@jimp/plugin-mask": "^0.9.8",
-        "@jimp/plugin-normalize": "^0.9.8",
-        "@jimp/plugin-print": "^0.9.8",
-        "@jimp/plugin-resize": "^0.9.8",
-        "@jimp/plugin-rotate": "^0.9.8",
-        "@jimp/plugin-scale": "^0.9.8",
-        "@jimp/plugin-shadow": "^0.9.8",
-        "@jimp/plugin-threshold": "^0.9.8",
+        "@jimp/plugin-blit": "^0.10.2",
+        "@jimp/plugin-blur": "^0.10.2",
+        "@jimp/plugin-circle": "^0.10.2",
+        "@jimp/plugin-color": "^0.10.2",
+        "@jimp/plugin-contain": "^0.10.2",
+        "@jimp/plugin-cover": "^0.10.2",
+        "@jimp/plugin-crop": "^0.10.2",
+        "@jimp/plugin-displace": "^0.10.2",
+        "@jimp/plugin-dither": "^0.10.2",
+        "@jimp/plugin-fisheye": "^0.10.2",
+        "@jimp/plugin-flip": "^0.10.2",
+        "@jimp/plugin-gaussian": "^0.10.2",
+        "@jimp/plugin-invert": "^0.10.2",
+        "@jimp/plugin-mask": "^0.10.2",
+        "@jimp/plugin-normalize": "^0.10.2",
+        "@jimp/plugin-print": "^0.10.2",
+        "@jimp/plugin-resize": "^0.10.2",
+        "@jimp/plugin-rotate": "^0.10.2",
+        "@jimp/plugin-scale": "^0.10.2",
+        "@jimp/plugin-shadow": "^0.10.2",
+        "@jimp/plugin-threshold": "^0.10.2",
         "core-js": "^3.4.1",
         "timm": "^1.6.1"
       }
     },
     "@jimp/png": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.9.8.tgz",
-      "integrity": "sha512-9CqR8d40zQCDhbnXHqcwkAMnvlV0vk9xSyE6LHjkYHS7x18Unsz5txQdsaEkEcXxCrOQSoWyITfLezlrWXRJAA==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.10.2.tgz",
+      "integrity": "sha512-3r5q9Ns3Gz8pcI8oBdGTY7d0TkkW4atZ12bknB1sABc3UYX69arqmTvrULMYhWf0M6n3tKHdnmdW2cTlFWIAbw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.9.8",
+        "@jimp/utils": "^0.10.2",
         "core-js": "^3.4.1",
         "pngjs": "^3.3.3"
       }
     },
     "@jimp/tiff": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.9.8.tgz",
-      "integrity": "sha512-eMxcpJivJqMByn2dZxUHLeh6qvVs5J/52kBF3TFa3C922OJ97D9l1C1h0WKUCBqFMWzMYapQQ4vwnLgpJ5tkow==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.10.2.tgz",
+      "integrity": "sha512-uuJF6ZMXo0EDyooho9RhwAY9YGcgUju1mw53N9BtU7E9Y+AxKn7miaK2niROmN2/ufmLJO8vS9zjpgAxv+zgKQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
         "core-js": "^3.4.1",
@@ -339,27 +339,28 @@
       }
     },
     "@jimp/types": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.9.8.tgz",
-      "integrity": "sha512-H5y/uqt0lqJ/ZN8pWqFG+pv8jPAppMKkTMByuC8YBIjWSsornwv44hjiWl93sbYhduLZY8ubz/CbX9jH2X6EwA==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.10.2.tgz",
+      "integrity": "sha512-XCgFhH8BR0ovxrEkDnKRXalEAUjo3vW9vwOFxfSrJR/YS/k0TsvYB6/+QAU/cGwcN8icmYdDyhq2yhJACAl13w==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/bmp": "^0.9.8",
-        "@jimp/gif": "^0.9.8",
-        "@jimp/jpeg": "^0.9.8",
-        "@jimp/png": "^0.9.8",
-        "@jimp/tiff": "^0.9.8",
+        "@jimp/bmp": "^0.10.2",
+        "@jimp/gif": "^0.10.2",
+        "@jimp/jpeg": "^0.10.2",
+        "@jimp/png": "^0.10.2",
+        "@jimp/tiff": "^0.10.2",
         "core-js": "^3.4.1",
         "timm": "^1.6.1"
       }
     },
     "@jimp/utils": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.9.8.tgz",
-      "integrity": "sha512-UK0Fu0eevQlpRXq5ff4o/71HJlpX9wJMddJjMYg9vUqCCl8ZnumRAljfShHFhGyO+Vc9IzN6dd8Y5JZZTp1KOw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.10.2.tgz",
+      "integrity": "sha512-B3fBgkE7t7S4X1RXKY5vfx+8QdUvN0AIbG2rM7csYTsudOczTtzimlP7XxunYtOwCYBLVswRWpqn8PZcRLWu2w==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "core-js": "^3.4.1"
+        "core-js": "^3.4.1",
+        "regenerator-runtime": "^0.13.3"
       }
     },
     "@sinonjs/commons": {
@@ -472,9 +473,9 @@
       "dev": true
     },
     "buffer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-      "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -574,9 +575,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "debug": {
       "version": "3.2.6",
@@ -609,9 +610,9 @@
       "dev": true
     },
     "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -844,14 +845,14 @@
       "dev": true
     },
     "jimp": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.9.8.tgz",
-      "integrity": "sha512-DHN4apKMwLIvD/TKO9tFfPuankNuVK98vCwHm/Jv9z5cJnrd38xhi+4I7IAGmDU3jIDlrEVhzTkFH1Ymv5yTQQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.10.2.tgz",
+      "integrity": "sha512-dt6n3P0LZyoqAiIUur+gJEKS55sCUUo19cKx8LTSZRqGizF4JN0jfRAnfnV4nxF+sINP2FN6SOi82gHcAMm1nQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/custom": "^0.9.8",
-        "@jimp/plugins": "^0.9.8",
-        "@jimp/types": "^0.9.8",
+        "@jimp/custom": "^0.10.2",
+        "@jimp/plugins": "^0.10.2",
+        "@jimp/types": "^0.10.2",
         "core-js": "^3.4.1",
         "regenerator-runtime": "^0.13.3"
       }
@@ -951,9 +952,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
-      "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
         "minimist": "^1.2.5"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/tooolbox/node-potrace#readme",
   "dependencies": {
-    "jimp": "^0.9.6"
+    "jimp": "^0.10.2"
   },
   "devDependencies": {
     "lodash": "^4.17.11",


### PR DESCRIPTION
Required to get https://github.com/oliver-moran/jimp/pull/870 (due to semver quirks, since jimp is in 0.x, consumers cannot easily switch from jimp 0.9 to 0.10).

Blocker for https://github.com/gatsbyjs/gatsby/pull/23139