### PR TITLE
Add function to return SVG as JSON Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ trace.loadImage('path/to/image.png', function(err) {
 
   trace.getSVG(); // returns SVG document contents
   trace.getPathTag(); // will return just <path> tag
+  trace.getJson(); // returns SVG document contents in JSON format
   trace.getSymbol('traced-image'); // will return <symbol> tag with given ID
 });
 

--- a/lib/Potrace.js
+++ b/lib/Potrace.js
@@ -1114,7 +1114,10 @@ Potrace.prototype = {
           fillRule: 'evenodd'
         });
       });
-
+      tagsArray.forEach((path, index) => {
+        path.id = index;
+      });
+      
       return tagsArray;
     }
 

--- a/lib/Potrace.js
+++ b/lib/Potrace.js
@@ -1108,7 +1108,7 @@ Potrace.prototype = {
       });
       this._pathlist.forEach(path => {
         tagsArray.push({
-          d: path,
+          d: utils.renderCurve(path.curve, scale),
           fill: fillColor,
           stroke: stroke,
           fillRule: 'evenodd'

--- a/lib/Potrace.js
+++ b/lib/Potrace.js
@@ -1075,15 +1075,10 @@ Potrace.prototype = {
   /**
    * Generates just <path> tag without rest of the SVG file
    *
-   * @param {string} [fillColor=auto] - overrides color from parameters
-   * @param {Object} [scale={ x: 1, y: 1 }] - override svg scale
-   * @param {number} [scale.x=1] - scale of the x dimension
-   * @param {number} [scale.y=1] - scale of the y dimension
-   * @param {String} [stroke=none] - override svg stroke value
-   * @param {boolean} [json=false] - return result as a json array of paths
+   * @param {String} [fillColor] - overrides color from parameters
    * @returns {String}
    */
-  getPathTag: function(fillColor='auto', scale={ x: 1, y: 1 }, stroke='black', json=false) {
+  getPathTag: function(fillColor, scale) {
     fillColor = arguments.length === 0 ? this._params.color : fillColor;
 
     if (fillColor === Potrace.COLOR_AUTO) {
@@ -1098,27 +1093,6 @@ Potrace.prototype = {
       this._bmToPathlist();
       this._processPath();
       this._processed = true;
-    }
-
-    if (json) {
-      const tagsArray = [];
-      tagsArray.push({
-        width: this._params.width || this._luminanceData.width,
-        height: this._params.height || this._luminanceData.height
-      });
-      this._pathlist.forEach(path => {
-        tagsArray.push({
-          d: utils.renderCurve(path.curve, scale),
-          fill: fillColor,
-          stroke: stroke,
-          fillRule: 'evenodd'
-        });
-      });
-      tagsArray.forEach((path, index) => {
-        path.id = index;
-      });
-      
-      return tagsArray;
     }
 
     var tag = '<path d="';
@@ -1169,6 +1143,54 @@ Potrace.prototype = {
         : '') +
       '\t' + this.getPathTag(this._params.color, scale) + '\n' +
       '</svg>';
+  },
+
+  /**
+   * Generates a JSON object with path information
+   *
+   * @param {string} [fillColor=auto] - overrides color from parameters
+   * @param {Object} [scale={ x: 1, y: 1 }] - override svg scale
+   * @param {number} [scale.x=1] - scale of the x dimension
+   * @param {number} [scale.y=1] - scale of the y dimension
+   * @param {String} [stroke=none] - override svg stroke value
+   * @param {boolean} [json=false] - return result as a json array of paths
+   * @returns {Array.<object>}
+   */
+  getJson: function(fillColor='auto', scale={ x: 1, y: 1 }, stroke='black') {
+    fillColor = arguments.length === 0 ? this._params.color : fillColor;
+
+    if (fillColor === Potrace.COLOR_AUTO) {
+      fillColor = this._params.blackOnWhite ? 'black' : 'white';
+    }
+
+    if (!this._imageLoaded) {
+      throw new Error('Image should be loaded first');
+    }
+
+    if (!this._processed) {
+      this._bmToPathlist();
+      this._processPath();
+      this._processed = true;
+    }
+
+    const tags = [];
+    tags.push({
+      width: this._params.width || this._luminanceData.width,
+      height: this._params.height || this._luminanceData.height
+    });
+    this._pathlist.forEach(path => {
+      tags.push({
+        d: utils.renderCurve(path.curve, scale),
+        fill: fillColor,
+        stroke: stroke,
+        fillRule: 'evenodd'
+      });
+    });
+    tags.forEach((path, index) => {
+      path.id = index;
+    });
+    
+    return tags;
   }
 };
 

--- a/lib/Potrace.js
+++ b/lib/Potrace.js
@@ -1075,10 +1075,15 @@ Potrace.prototype = {
   /**
    * Generates just <path> tag without rest of the SVG file
    *
-   * @param {String} [fillColor] - overrides color from parameters
+   * @param {string} [fillColor=auto] - overrides color from parameters
+   * @param {Object} [scale={ x: 1, y: 1 }] - override svg scale
+   * @param {number} [scale.x=1] - scale of the x dimension
+   * @param {number} [scale.y=1] - scale of the y dimension
+   * @param {String} [stroke=none] - override svg stroke value
+   * @param {boolean} [json=false] - return result as a json array of paths
    * @returns {String}
    */
-  getPathTag: function(fillColor, scale) {
+  getPathTag: function(fillColor='auto', scale={ x: 1, y: 1 }, stroke='black', json=false) {
     fillColor = arguments.length === 0 ? this._params.color : fillColor;
 
     if (fillColor === Potrace.COLOR_AUTO) {
@@ -1093,6 +1098,24 @@ Potrace.prototype = {
       this._bmToPathlist();
       this._processPath();
       this._processed = true;
+    }
+
+    if (json) {
+      const tagsArray = [];
+      tagsArray.push({
+        width: this._params.width || this._luminanceData.width,
+        height: this._params.height || this._luminanceData.height
+      });
+      this._pathlist.forEach(path => {
+        tagsArray.push({
+          d: path,
+          fill: fillColor,
+          stroke: stroke,
+          fillRule: 'evenodd'
+        });
+      });
+
+      return tagsArray;
     }
 
     var tag = '<path d="';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "potrace",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
In addition to returning SVG document contents, a <path> tag, and a <symbol> tag, this pull request adds the ability to return a JSON Array of the SVG paths, `getJSON()`. This allows users to create their own SVGs using the given paths, and allows for easier data manipulation. The information returned from the new function is similar to what is returned from the other functions. It holds the width and height data of the svg, and the data of each of the svg's created paths.

The structure of the resulting array is as follows:
```
[
  {
    height: 320,
    width: 240
  },
  {
    d: "M 636.282 50.537 C 628.002 52.767, ...",
    id: 1,
    fill: "black",
    stroke: "black",
    fillRule: "evenodd"
  },
  {
    d: "M 639.487 67.746 C 632.040 70.400, ...",
    id: 2,
    fill: "black",
    stroke: "black",
    fillRule: "evenodd"
  },
  ...
]
```
